### PR TITLE
V2.3.0 fixes

### DIFF
--- a/CheapoDC/CDCSetup.cpp
+++ b/CheapoDC/CDCSetup.cpp
@@ -959,7 +959,7 @@ void CDCSetup::setWeatherSource(weatherSource source, bool forceUpdate)
         }
         else if (source == INTERNALSOURCE) // Treat as OpenMeteo for testing purposes
         {
-          if (((this->_humiditySensorSDAPin < 0) || (this->_humiditySensorSCLPin < 0)) && !forceUpdate)
+          if (((this->_humiditySensorSDAPin < 0) || (this->_humiditySensorSCLPin < 0) || !this->_humiditySensorStatus) && !forceUpdate)
           {
             LOG_ERROR("setWeatherSource", "Internal Source selected but Humidity sensor pins not set. Keeping previous Weather Source.");
             this->_currentWeatherSource = previousWeatherSource;

--- a/CheapoDC/CDCSetup.cpp
+++ b/CheapoDC/CDCSetup.cpp
@@ -604,8 +604,8 @@ bool CDCSetup::setupWiFi(void)
   {
     LOG_DEBUG("setupWiFi", "Using WiFi Defaults");
     strlcpy(this->_wifiConfig.hostname, CDC_DEFAULT_HOSTNAME, sizeof(this->_wifiConfig.hostname));
-    this->_wifiConfig.connectAttempts, CDC_DEFAULT_WIFI_CONNECTATTEMPTS;
-    this->_wifiConfig.tryAPs, CDC_DEFAULT_WIFI_TRYAPS;
+    this->_wifiConfig.connectAttempts = CDC_DEFAULT_WIFI_CONNECTATTEMPTS;
+    this->_wifiConfig.tryAPs = CDC_DEFAULT_WIFI_TRYAPS;
     strlcpy(this->_wifiConfig.ssid, CDC_DEFAULT_WIFI_SSID, sizeof(this->_wifiConfig.ssid));
     strlcpy(this->_wifiConfig.password, CDC_DEFAULT_WIFI_PASSWORD, sizeof(this->_wifiConfig.password));
 
@@ -624,8 +624,23 @@ bool CDCSetup::setupWiFi(void)
   {
 
     strlcpy(this->_wifiConfig.hostname, doc["hostname"] | CDC_DEFAULT_HOSTNAME, sizeof(this->_wifiConfig.hostname));
-    this->_wifiConfig.connectAttempts = (doc["connectAttempts"] | CDC_DEFAULT_WIFI_CONNECTATTEMPTS);
-    this->_wifiConfig.tryAPs = (doc["tryAPs"] | CDC_DEFAULT_WIFI_TRYAPS);
+    if (doc["connectAttempts"].is<int>())
+      this->_wifiConfig.connectAttempts = doc["connectAttempts"].as<int>();
+    else if (doc["connectAttempts"].is<const char*>())
+      this->_wifiConfig.connectAttempts = atoi(doc["connectAttempts"].as<const char*>());
+    else
+      this->_wifiConfig.connectAttempts = CDC_DEFAULT_WIFI_CONNECTATTEMPTS;
+    if (this->_wifiConfig.connectAttempts <= 0)
+      this->_wifiConfig.connectAttempts = CDC_DEFAULT_WIFI_CONNECTATTEMPTS;
+
+    if (doc["tryAPs"].is<int>())
+      this->_wifiConfig.tryAPs = doc["tryAPs"].as<int>();
+    else if (doc["tryAPs"].is<const char*>())
+      this->_wifiConfig.tryAPs = atoi(doc["tryAPs"].as<const char*>());
+    else
+      this->_wifiConfig.tryAPs = CDC_DEFAULT_WIFI_TRYAPS;
+    if (this->_wifiConfig.tryAPs <= 0)
+      this->_wifiConfig.tryAPs = 1;
 
     LOG_DEBUG("setupWiFi", "hostname:" << this->_wifiConfig.hostname);
     LOG_DEBUG("setupWiFi", "Connection attempts:" << this->_wifiConfig.connectAttempts);

--- a/CheapoDC/CDCSetup.cpp
+++ b/CheapoDC/CDCSetup.cpp
@@ -624,6 +624,7 @@ bool CDCSetup::setupWiFi(void)
   {
 
     strlcpy(this->_wifiConfig.hostname, doc["hostname"] | CDC_DEFAULT_HOSTNAME, sizeof(this->_wifiConfig.hostname));
+
     if (doc["connectAttempts"].is<int>())
       this->_wifiConfig.connectAttempts = doc["connectAttempts"].as<int>();
     else if (doc["connectAttempts"].is<const char*>())
@@ -640,7 +641,7 @@ bool CDCSetup::setupWiFi(void)
     else
       this->_wifiConfig.tryAPs = CDC_DEFAULT_WIFI_TRYAPS;
     if (this->_wifiConfig.tryAPs <= 0)
-      this->_wifiConfig.tryAPs = 1;
+      this->_wifiConfig.tryAPs = CDC_DEFAULT_WIFI_TRYAPS;
 
     LOG_DEBUG("setupWiFi", "hostname:" << this->_wifiConfig.hostname);
     LOG_DEBUG("setupWiFi", "Connection attempts:" << this->_wifiConfig.connectAttempts);

--- a/CheapoDC/CDCSetup.cpp
+++ b/CheapoDC/CDCSetup.cpp
@@ -1079,7 +1079,7 @@ String CDCSetup::getDateTime()
   char dtBuff[CDC_MAX_DATETIME_STRING] = {};
   struct tm lTime;
 
-  getLocalTime(&lTime);
+  getLocalTime(&lTime, 10);
   
   sprintf(dtBuff, CDC_DATE_TIME, mydayShortStr[lTime.tm_wday], mymonthShortStr[lTime.tm_mon], lTime.tm_mday, (lTime.tm_year + 1900), lTime.tm_hour, lTime.tm_min, second(lTime.tm_sec));
 
@@ -1093,7 +1093,7 @@ String CDCSetup::getDateTime( time_t t )
   tmElements_t lTElements;
   time_t local_t = t + this->_location.timezone;
 
-  getLocalTime(&lTime);
+  getLocalTime(&lTime, 10);
 
   if (lTime.tm_isdst == 1)
     local_t = local_t + this->_location.DSTOffset;
@@ -1109,7 +1109,7 @@ String CDCSetup::getDate( )
   char dtBuff[CDC_MAX_DATETIME_STRING] = {};
   struct tm lTime;
 
-  getLocalTime(&lTime);
+  getLocalTime(&lTime, 10);
   
   sprintf(dtBuff, CDC_DATE, mydayShortStr[lTime.tm_wday], mymonthShortStr[lTime.tm_mon], lTime.tm_mday, (lTime.tm_year + 1900));
 
@@ -1123,7 +1123,7 @@ String CDCSetup::getDate( time_t t )
   tmElements_t lTElements;
   time_t local_t = t + this->_location.timezone;
 
-  getLocalTime(&lTime);
+  getLocalTime(&lTime, 10);
 
   if (lTime.tm_isdst == 1)
     local_t = local_t + this->_location.DSTOffset;
@@ -1140,7 +1140,7 @@ String CDCSetup::getTime( )
   char dtBuff[CDC_MAX_DATETIME_STRING];
   struct tm lTime;
 
-  getLocalTime(&lTime);
+  getLocalTime(&lTime, 10);
   
   sprintf(dtBuff, CDC_TIME, lTime.tm_hour, lTime.tm_min, second(lTime.tm_sec));
 
@@ -1154,7 +1154,7 @@ String CDCSetup::getTime( time_t t )
   tmElements_t lTElements;
   time_t local_t = t + this->_location.timezone;
 
-  getLocalTime(&lTime);
+  getLocalTime(&lTime, 10);
   
   if (lTime.tm_isdst == 1)
     local_t = local_t + this->_location.DSTOffset;
@@ -1169,7 +1169,7 @@ int CDCSetup::getSecond()
 {
   struct tm lTime;
 
-  getLocalTime(&lTime);
+  getLocalTime(&lTime, 10);
 
   return lTime.tm_sec;
 }
@@ -1178,7 +1178,7 @@ int CDCSetup::getMinute()
 {
   struct tm lTime;
 
-  getLocalTime(&lTime);
+  getLocalTime(&lTime, 10);
 
   return lTime.tm_min;
 }

--- a/CheapoDC/CDCSetup.cpp
+++ b/CheapoDC/CDCSetup.cpp
@@ -952,58 +952,60 @@ void CDCSetup::setAmbientTemperatureExternal(float temperature)
 
 void CDCSetup::setWeatherSource(weatherSource source, bool forceUpdate)
 {
-    weatherSource previousWeatherSource = this->_currentWeatherSource;
-    if ((source < OPENMETEO) || (source > INTERNALSOURCE))
+  weatherSource previousWeatherSource = this->_currentWeatherSource;
+  if ((source < OPENMETEO) || (source > INTERNALSOURCE)) // In range check
+  {
+    LOG_ALERT("setWeatherSource", "Invalid weather source: " << source << " keeping current source " << previousWeatherSource);
+    this->_currentWeatherSource = previousWeatherSource;
+  } // In range check
+  else if ( source != previousWeatherSource) // Source change check
+  {
+    if ((source == INTERNALSOURCE) && (!forceUpdate) && ((this->_humiditySensorSDAPin < 0) || (this->_humiditySensorSCLPin < 0) || !this->_humiditySensorStatus))
     {
-        LOG_ALERT("setWeatherSource", "Invalid weather source: " << source << " keeping current source " << previousWeatherSource);
-        this->_currentWeatherSource = previousWeatherSource;
+      LOG_ERROR("setWeatherSource", "Internal Source selected but Humidity sensor pins not set. Keeping previous Weather Source.");
+      this->_currentWeatherSource = previousWeatherSource;
     }
-    else if ( source != previousWeatherSource)
+    else // Pass Internal source error check
     {
-        this->_currentWeatherSource = source;
-        memset(this->_weatherAPIURL, '\0', sizeof(this->_weatherAPIURL));
-        memset(this->_weatherIconURL, '\0', sizeof(this->_weatherIconURL));
-        if (source ==  OPENMETEO)
-        {
-          strlcpy(this->_weatherAPIURL, CDC_OPENMETEO_APIURL, sizeof(this->_weatherAPIURL));
-          strlcpy(this->_weatherIconURL, CDC_OPENMETEO_ICONURL, sizeof(this->_weatherIconURL));
-        }
-        else if (source == OPENWEATHERSOURCE)
-        {
-          strlcpy(this->_weatherAPIURL, CDC_OPENWEATHER_APIURL, sizeof(this->_weatherAPIURL));
-          strlcpy(this->_weatherIconURL, CDC_OPENWEATHER_ICONURL, sizeof(this->_weatherIconURL));
-        }
-        else if (source == INTERNALSOURCE) // Treat as OpenMeteo for testing purposes
-        {
-          if (((this->_humiditySensorSDAPin < 0) || (this->_humiditySensorSCLPin < 0) || !this->_humiditySensorStatus) && !forceUpdate)
-          {
-            LOG_ERROR("setWeatherSource", "Internal Source selected but Humidity sensor pins not set. Keeping previous Weather Source.");
-            this->_currentWeatherSource = previousWeatherSource;
-          }
-          else
-          {
-            strlcpy(this->_weatherAPIURL, CDC_WEATHERSOURCE_APIURL_NA, sizeof(this->_weatherAPIURL));
-            strlcpy(this->_weatherIconURL, CDC_WEATHERSOURCE_ICONURL_NA, sizeof(this->_weatherIconURL));
-            memset(this->_currentWeather.weatherDescription, '\0', sizeof(this->_currentWeather.weatherDescription));
-            strlcpy(this->_currentWeather.weatherDescription, CDC_WEATHERSOURCE_DESC_NA, sizeof(this->_currentWeather.weatherDescription));
-            memset(this->_currentWeather.weatherIcon, '\0', sizeof(this->_currentWeather.weatherIcon));
-            strlcpy(this->_currentWeather.weatherIcon, CDC_NA, sizeof(this->_currentWeather.weatherIcon));
-            strlcpy(this->_currentWeather.weatherUpdateLocation, CDC_INTERNALSOURCE_LOCATION_NAME, sizeof(this->_currentWeather.weatherUpdateLocation));
-          }
-        }
-        else
-        {
-          strlcpy(this->_weatherAPIURL, CDC_WEATHERSOURCE_APIURL_NA, sizeof(this->_weatherAPIURL));
-          strlcpy(this->_weatherIconURL, CDC_WEATHERSOURCE_ICONURL_NA, sizeof(this->_weatherIconURL));
-          memset(this->_currentWeather.weatherDescription, '\0', sizeof(this->_currentWeather.weatherDescription));
-          strlcpy(this->_currentWeather.weatherDescription, CDC_WEATHERSOURCE_DESC_NA, sizeof(this->_currentWeather.weatherDescription));
-          memset(this->_currentWeather.weatherIcon, '\0', sizeof(this->_currentWeather.weatherIcon));
-          strlcpy(this->_currentWeather.weatherIcon, CDC_NA, sizeof(this->_currentWeather.weatherIcon));
-          strlcpy(this->_currentWeather.weatherUpdateLocation, CDC_EXTERNALSOURCE_LOCATION_NAME, sizeof(this->_currentWeather.weatherUpdateLocation));
+      this->_currentWeatherSource = source;
+      memset(this->_weatherAPIURL, '\0', sizeof(this->_weatherAPIURL));
+      memset(this->_weatherIconURL, '\0', sizeof(this->_weatherIconURL));
+      if (source ==  OPENMETEO) // Change to OPENMETEO
+      {
+        strlcpy(this->_weatherAPIURL, CDC_OPENMETEO_APIURL, sizeof(this->_weatherAPIURL));
+        strlcpy(this->_weatherIconURL, CDC_OPENMETEO_ICONURL, sizeof(this->_weatherIconURL));
+      }  // Change to OPENMETEO
+      else if (source == OPENWEATHERSOURCE) // Change to OPENWEATHER
+      {
+        strlcpy(this->_weatherAPIURL, CDC_OPENWEATHER_APIURL, sizeof(this->_weatherAPIURL));
+        strlcpy(this->_weatherIconURL, CDC_OPENWEATHER_ICONURL, sizeof(this->_weatherIconURL));
+      }  // Change to OPENWEATHER
+      else if (source == EXTERNALSOURCE) // Change to EXTERNALSOURCE
+      {
+        strlcpy(this->_weatherAPIURL, CDC_WEATHERSOURCE_APIURL_NA, sizeof(this->_weatherAPIURL));
+        strlcpy(this->_weatherIconURL, CDC_WEATHERSOURCE_ICONURL_NA, sizeof(this->_weatherIconURL));
+        memset(this->_currentWeather.weatherDescription, '\0', sizeof(this->_currentWeather.weatherDescription));
+        strlcpy(this->_currentWeather.weatherDescription, CDC_WEATHERSOURCE_DESC_NA, sizeof(this->_currentWeather.weatherDescription));
+        memset(this->_currentWeather.weatherIcon, '\0', sizeof(this->_currentWeather.weatherIcon));
+        strlcpy(this->_currentWeather.weatherIcon, CDC_NA, sizeof(this->_currentWeather.weatherIcon));
+        strlcpy(this->_currentWeather.weatherUpdateLocation, CDC_EXTERNALSOURCE_LOCATION_NAME, sizeof(this->_currentWeather.weatherUpdateLocation));
+      } // Change to EXTERNALSOURCE
+      else if (source == INTERNALSOURCE) // Change to INTERNALSOURCE
+      {       
+        strlcpy(this->_weatherAPIURL, CDC_WEATHERSOURCE_APIURL_NA, sizeof(this->_weatherAPIURL));
+        strlcpy(this->_weatherIconURL, CDC_WEATHERSOURCE_ICONURL_NA, sizeof(this->_weatherIconURL));
+        memset(this->_currentWeather.weatherDescription, '\0', sizeof(this->_currentWeather.weatherDescription));
+        strlcpy(this->_currentWeather.weatherDescription, CDC_WEATHERSOURCE_DESC_NA, sizeof(this->_currentWeather.weatherDescription));
+        memset(this->_currentWeather.weatherIcon, '\0', sizeof(this->_currentWeather.weatherIcon));
+        strlcpy(this->_currentWeather.weatherIcon, CDC_NA, sizeof(this->_currentWeather.weatherIcon));
+        strlcpy(this->_currentWeather.weatherUpdateLocation, CDC_INTERNALSOURCE_LOCATION_NAME, sizeof(this->_currentWeather.weatherUpdateLocation));
+      } // Change to INTERNALSOURCE
+      else  // Something is wrong...
+      {
+        LOG_ERROR("setWeatherSource", "Invalid weather source: " << source << ", not sure how we got here.");
+      } 
 
-        }
-
-        // Reset query & update times as well as temperature, humidity & dew point
+      // Reset query & update times as well as temperature, humidity & dew point
       strlcpy(this->_currentWeather.lastWeatherQueryTime, CDC_NA, sizeof(this->_currentWeather.lastWeatherQueryTime));
       strlcpy(this->_currentWeather.lastWeatherQueryDate, CDC_NA, sizeof(this->_currentWeather.lastWeatherQueryDate));
       strlcpy(this->_currentWeather.lastWeatherUpdateTime, CDC_NA, sizeof(this->_currentWeather.lastWeatherUpdateTime));
@@ -1011,9 +1013,10 @@ void CDCSetup::setWeatherSource(weatherSource source, bool forceUpdate)
       this->_currentWeather.ambientTemperature = CDC_TEMPERATURE_NOT_SET;
       this->_currentWeather.humidity = 0.0F;
       this->_currentWeather.dewPoint = 0.0F;
-    }
-    
-    LOG_DEBUG("setWeatherSource", "Set weather source set to: " << this->_currentWeatherSource);
+    } // Pass Internal source error check
+  } // Source change check
+  
+  LOG_DEBUG("setWeatherSource", "Set weather source set to: " << this->_currentWeatherSource);
 }
 
 void CDCSetup::calculateAndSetDewPoint()

--- a/CheapoDC/CDCWebSrvr.cpp
+++ b/CheapoDC/CDCWebSrvr.cpp
@@ -502,8 +502,22 @@ void setupServers(void) {
     request->send(LittleFS, "/listfiles.html", String(), false, processor);
   });
 
+  // File list
   CDCWebServer->on("/filelist", HTTP_GET, [](AsyncWebServerRequest *request) {
-    request->send(200, "text/html", filelist, processor);
+    String fileListResponse = processor("TMFL");
+    AsyncWebServerResponse *response = request->beginChunkedResponse("text/plain", [fileListResponse](uint8_t *buffer, size_t maxLen, size_t index) -> size_t {
+      unsigned int fileListLength = fileListResponse.length();
+      if (index >= fileListLength) {
+        return 0; // No more data to send
+      }
+
+      const int bytesToSend = min( (size_t)1024, min(maxLen, (fileListLength - index)));
+      memcpy(buffer, fileListResponse.c_str() + index, bytesToSend);
+
+      return bytesToSend;
+
+    });
+      request->send(response);
   });
 
   // Assorted special function pages and images
@@ -533,7 +547,19 @@ void setupServers(void) {
 
   CDCWebServer->on("/delete", HTTP_GET, [](AsyncWebServerRequest *request) {
     processDelete(request);
-    request->send(200, "text/html", filelist, processor);
+    String fileListResponse = processor("TMFL");
+    AsyncWebServerResponse *response = request->beginChunkedResponse("text/plain", [fileListResponse](uint8_t *buffer, size_t maxLen, size_t index) -> size_t {
+      unsigned int fileListLength = fileListResponse.length();
+      if (index >= fileListLength) {
+        return 0; // No more data to send
+      }
+
+      const int bytesToSend = min( (size_t)1024, min(maxLen, (fileListLength - index)));
+      memcpy(buffer, fileListResponse.c_str() + index, bytesToSend);
+
+      return bytesToSend;
+    });
+    request->send(response);
   });
 
   CDCWebServer->on("/reboot", HTTP_GET, [](AsyncWebServerRequest *request) {

--- a/CheapoDC/CDCWebSrvr.cpp
+++ b/CheapoDC/CDCWebSrvr.cpp
@@ -707,13 +707,14 @@ void setupHttpOTA() {
   File file = LittleFS.open(CDC_HTTP_OTA_ROOT_CA_FILE, "r");
   if (!file)
   {
-    const char* root_ca = WEB_OTA_ROOT_CA;
+    // Use CA certs bundle supported by esp32FOTA
     LOG_DEBUG("setupHttpOTA", "No Root CA file found: " << CDC_HTTP_OTA_ROOT_CA_FILE << " Using default.");
-    CryptoMemAsset  *MyRootCA = new CryptoMemAsset("Root CA", root_ca, strlen(root_ca)+1 );
-    CDCFota->setRootCA( MyRootCA );
+    CDCFota->useBundledCerts(true);
   } else {
+    // Use CA cert file from LittleFS
     file.close();
     LOG_ALERT("setupHttpOTA", "Root CA file found: " << CDC_HTTP_OTA_ROOT_CA_FILE << " Using it instead of default.");
+    CDCFota->useBundledCerts(false);
     CryptoFileAsset *MyRootCA =  new CryptoFileAsset(CDC_HTTP_OTA_ROOT_CA_FILE, &LittleFS);
     CDCFota->setRootCA( MyRootCA );  
   }

--- a/CheapoDC/CDCdefines.h
+++ b/CheapoDC/CDCdefines.h
@@ -55,7 +55,7 @@
 #define CDC_DEFAULT_WIFI_SSID "defaultSSID"         // default SSID for STA mode. Can also be set in CDCWiFi.json
 #define CDC_DEFAULT_WIFI_PASSWORD "defaultPassword" // default WiFi Password. Can also be set in CDCWiFi.json
 #define CDC_DEFAULT_WIFI_AP_PASSWORD "cheapodc"     // WiFi password for AP mode
-#define CDC_DEFAULT_WIFI_CONNECTATTEMPTS 15         // Number of times to try to connect to an AP when in STA mode
+#define CDC_DEFAULT_WIFI_CONNECTATTEMPTS 10         // Number of times to try to connect to an AP when in STA mode
 #define CDC_DEFAULT_WIFI_TRYAPS 1                   // Number of times to cycle through APs when in STA mode
 //#define CDC_ENABLE_WIFI_TX_POWER_MOD WIFI_POWER_8_5dBm // Uncomment to adjust WiFi TX power if you are having connection issues
 
@@ -158,43 +158,7 @@
 #ifdef CDC_ENABLE_HTTP_OTA
 #define CDC_NO_FW_UPDATE_RESPONSE "NOFWUPDATE"
 #define CDC_HTTP_OTA_ROOT_CA_FILE "/root_ca.pem"     // Can be placed in the data partition to override the default below
-#define WEB_OTA_ROOT_CA \
-"-----BEGIN CERTIFICATE-----\n" \
-"MIIF3jCCA8agAwIBAgIQAf1tMPyjylGoG7xkDjUDLTANBgkqhkiG9w0BAQwFADCB\n" \
-"iDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCk5ldyBKZXJzZXkxFDASBgNVBAcTC0pl\n" \
-"cnNleSBDaXR5MR4wHAYDVQQKExVUaGUgVVNFUlRSVVNUIE5ldHdvcmsxLjAsBgNV\n" \
-"BAMTJVVTRVJUcnVzdCBSU0EgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwHhcNMTAw\n" \
-"MjAxMDAwMDAwWhcNMzgwMTE4MjM1OTU5WjCBiDELMAkGA1UEBhMCVVMxEzARBgNV\n" \
-"BAgTCk5ldyBKZXJzZXkxFDASBgNVBAcTC0plcnNleSBDaXR5MR4wHAYDVQQKExVU\n" \
-"aGUgVVNFUlRSVVNUIE5ldHdvcmsxLjAsBgNVBAMTJVVTRVJUcnVzdCBSU0EgQ2Vy\n" \
-"dGlmaWNhdGlvbiBBdXRob3JpdHkwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIK\n" \
-"AoICAQCAEmUXNg7D2wiz0KxXDXbtzSfTTK1Qg2HiqiBNCS1kCdzOiZ/MPans9s/B\n" \
-"3PHTsdZ7NygRK0faOca8Ohm0X6a9fZ2jY0K2dvKpOyuR+OJv0OwWIJAJPuLodMkY\n" \
-"tJHUYmTbf6MG8YgYapAiPLz+E/CHFHv25B+O1ORRxhFnRghRy4YUVD+8M/5+bJz/\n" \
-"Fp0YvVGONaanZshyZ9shZrHUm3gDwFA66Mzw3LyeTP6vBZY1H1dat//O+T23LLb2\n" \
-"VN3I5xI6Ta5MirdcmrS3ID3KfyI0rn47aGYBROcBTkZTmzNg95S+UzeQc0PzMsNT\n" \
-"79uq/nROacdrjGCT3sTHDN/hMq7MkztReJVni+49Vv4M0GkPGw/zJSZrM233bkf6\n" \
-"c0Plfg6lZrEpfDKEY1WJxA3Bk1QwGROs0303p+tdOmw1XNtB1xLaqUkL39iAigmT\n" \
-"Yo61Zs8liM2EuLE/pDkP2QKe6xJMlXzzawWpXhaDzLhn4ugTncxbgtNMs+1b/97l\n" \
-"c6wjOy0AvzVVdAlJ2ElYGn+SNuZRkg7zJn0cTRe8yexDJtC/QV9AqURE9JnnV4ee\n" \
-"UB9XVKg+/XRjL7FQZQnmWEIuQxpMtPAlR1n6BB6T1CZGSlCBst6+eLf8ZxXhyVeE\n" \
-"Hg9j1uliutZfVS7qXMYoCAQlObgOK6nyTJccBz8NUvXt7y+CDwIDAQABo0IwQDAd\n" \
-"BgNVHQ4EFgQUU3m/WqorSs9UgOHYm8Cd8rIDZsswDgYDVR0PAQH/BAQDAgEGMA8G\n" \
-"A1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQEMBQADggIBAFzUfA3P9wF9QZllDHPF\n" \
-"Up/L+M+ZBn8b2kMVn54CVVeWFPFSPCeHlCjtHzoBN6J2/FNQwISbxmtOuowhT6KO\n" \
-"VWKR82kV2LyI48SqC/3vqOlLVSoGIG1VeCkZ7l8wXEskEVX/JJpuXior7gtNn3/3\n" \
-"ATiUFJVDBwn7YKnuHKsSjKCaXqeYalltiz8I+8jRRa8YFWSQEg9zKC7F4iRO/Fjs\n" \
-"8PRF/iKz6y+O0tlFYQXBl2+odnKPi4w2r78NBc5xjeambx9spnFixdjQg3IM8WcR\n" \
-"iQycE0xyNN+81XHfqnHd4blsjDwSXWXavVcStkNr/+XeTWYRUc+ZruwXtuhxkYze\n" \
-"Sf7dNXGiFSeUHM9h4ya7b6NnJSFd5t0dCy5oGzuCr+yDZ4XUmFF0sbmZgIn/f3gZ\n" \
-"XHlKYC6SQK5MNyosycdiyA5d9zZbyuAlJQG03RoHnHcAP9Dc1ew91Pq7P8yF1m9/\n" \
-"qS3fuQL39ZeatTXaw2ewh0qpKJ4jjv9cJ2vhsE/zB+4ALtRZh8tSQZXq9EfX7mRB\n" \
-"VXyNWQKV3WKdwrnuWih0hKWbt5DHDAff9Yk2dDLWKMGwsAvgnEzDHNb842m1R0aB\n" \
-"L6KCq9NjRHDEjf8tM7qtj3u1cIiuPhnPQCjY/MiQu12ZIvVS5ljFH4gxQ+6IHdfG\n" \
-"jjxDah2nGN59PRbxYvnKkKj9\n" \
-"-----END CERTIFICATE-----\n" \
-""
-#else
+#else // CDC_ENABLE_HTTP_OTA
 #define CDC_NO_FW_UPDATE_RESPONSE "NOSUPPORT"
 #endif  // CDC_ENABLE_HTTP_OTA
 

--- a/CheapoDC/CDCesp32FOTA.cpp
+++ b/CheapoDC/CDCesp32FOTA.cpp
@@ -31,6 +31,8 @@
 */
 
 #include "CDCesp32FOTA.hpp"
+// include ESP32CertBundle Arduino library for root CA certificates management
+#include <esp32_cert_bundle.h>
 
 
 // arduino-esp32 core 2.x => 3.x migration
@@ -192,6 +194,7 @@ void esp32FOTA::setConfig( FOTAConfig_t cfg )
     _cfg.signature_len = cfg.signature_len;
     _cfg.allow_reuse   = cfg.allow_reuse;
     _cfg.use_http10    = cfg.use_http10;
+    _cfg.use_bundled_certs = cfg.use_bundled_certs;
 }
 
 
@@ -240,7 +243,15 @@ void esp32FOTA::setupCryptoAssets()
 }
 
 
-
+/* Enable ESP-IDF bundled certs */
+void esp32FOTA::useBundledCerts(bool enable)
+{
+    _cfg.use_bundled_certs = enable;
+    if (enable) {
+        _cfg.unsafe = false;     // strict
+        _cfg.root_ca = nullptr;  // disable custom CA
+    }
+}
 void esp32FOTA::handle()
 {
   if ( execHTTPcheck() ) {
@@ -371,34 +382,73 @@ bool esp32FOTA::setupHTTP( const char* url )
     _http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
     _http.setReuse(_cfg.allow_reuse);
     _http.useHTTP10(_cfg.use_http10);
-    
 
     log_i("Connecting to: %s", url );
-    if( String(url).startsWith("https") ) {
-        if (!_cfg.unsafe) {
-            if( !_cfg.root_ca ) {
-                log_e("A strict security context has been set but no RootCA was provided");
-                return false;
+
+    bool is_https = String(url).startsWith("https");
+
+    if (is_https) {
+
+        bool https_initialized = false;
+
+        /* ================================
+           1. Bundled ESP-IDF CA certificate
+           ================================ */
+#if ESP_ARDUINO_VERSION_MAJOR >= 3
+        if (!https_initialized && _cfg.use_bundled_certs) {
+            // Modified to use ESP32CertBundle Arduino library
+
+            if (x509_crt_bundle != nullptr) {
+                log_i("Using built-in ESP-IDF certificate bundle (%u bytes)", x509_crt_bundle_len);
+
+                _client.setCACertBundle(x509_crt_bundle, x509_crt_bundle_len);
+                _http.begin(_client, url);
+                https_initialized = true;
+            } else {
+                log_w("Bundled certs requested, but CA bundle not linked. Falling back.");
             }
-            if( _cfg.root_ca->size() == 0 ) {
-                log_e("A strict security context has been set but an empty RootCA was provided");
+        }
+#endif
+
+        /* ================================
+           2. Custom root CA certificate
+           ================================ */
+        if (!https_initialized && !_cfg.unsafe && _cfg.root_ca) {
+            if (_cfg.root_ca->size() == 0) {
+                log_e("Strict HTTPS but empty RootCA provided");
                 return false;
             }
             rootcastr = _cfg.root_ca->get();
-            if( !rootcastr ) {
-                log_e("Unable to get RootCA, aborting");
-                log_e("rootcastr=%s", rootcastr);
+            if (!rootcastr) {
+                log_e("Strict HTTPS but failed to get RootCA contents");
                 return false;
             }
-            log_d("Loading root_ca.pem");
-            _client.setCACert( rootcastr );
-        } else {
-            // We're downloading from a secure URL, but we don't want to validate the root cert.
-            _client.setInsecure();
+            log_i("Using custom RootCA for TLS");
+            _client.setCACert(rootcastr);
+            _http.begin(_client, url);
+            https_initialized = true;
         }
-        _http.begin( _client, url );
+
+        /* ================================
+           3. Insecure HTTPS
+           ================================ */
+        if (!https_initialized && _cfg.unsafe) {
+            log_w("Insecure HTTPS enabled");
+            _client.setInsecure();
+            _http.begin(_client, url);
+            https_initialized = true;
+        }
+
+        /* ================================
+           4. No CA available (strict)
+           ================================ */
+        if (!https_initialized) {
+            log_e("Strict HTTPS enabled but no CA source available (neither bundled nor custom)");
+            return false;
+        }
+
     } else {
-        _http.begin( url );
+        _http.begin(url);
     }
 
     if( extraHTTPHeaders.size() > 0 ) {
@@ -909,6 +959,7 @@ bool esp32FOTA::forceUpdate(const char* firmwareHost, uint16_t firmwarePort, con
 {
     static String firmwareURL("http");
     if ( firmwarePort == 443 || firmwarePort == 4433 ) firmwareURL += "s";
+    firmwareURL += "://";
     firmwareURL += String(firmwareHost);
     firmwareURL += ":";
     firmwareURL += String(firmwarePort);

--- a/CheapoDC/CDCesp32FOTA.hpp
+++ b/CheapoDC/CDCesp32FOTA.hpp
@@ -33,9 +33,10 @@
      - Update from Stream (e.g deported update via SD, http or gzupdater)
 */
 
-#ifndef esp32fota_h
+#pragma once
+
 #define esp32fota_h
-#define DISABLE_ALL_ESP32FOTA_LIBRARY_WARNINGS
+#define DISABLE_ALL_LIBRARY_WARNINGS
 
 extern "C" {
   #include "C_semver.h"
@@ -59,41 +60,41 @@ extern "C" {
 
 // inherit includes from sketch, detect SPIFFS first for legacy support
 #if __has_include(<SPIFFS.h>) || defined _SPIFFS_H_
-  #if !defined(DISABLE_ALL_ESP32FOTA_LIBRARY_WARNINGS)
+  #if !defined(DISABLE_ALL_LIBRARY_WARNINGS)
   #pragma message "Using SPIFFS for certificate validation"
   #endif
   #include <SPIFFS.h>
   #define FOTA_FS &SPIFFS
 #elif __has_include(<LittleFS.h>) || defined _LiffleFS_H_
-  #if !defined(DISABLE_ALL_ESP32FOTA_LIBRARY_WARNINGS)
+  #if !defined(DISABLE_ALL_LIBRARY_WARNINGS)
   #pragma message "Using LittleFS for certificate validation"
   #endif
   #include <LittleFS.h>
   #define FOTA_FS &LittleFS
 #elif __has_include(<SD.h>) || defined _SD_H_
-  #if !defined(DISABLE_ALL_ESP32FOTA_LIBRARY_WARNINGS)
+  #if !defined(DISABLE_ALL_LIBRARY_WARNINGS)
   #pragma message "Using SD for certificate validation"
   #endif
   #include <SD.h>
   #define FOTA_FS &SD
 #elif __has_include(<SD_MMC.h>) || defined _SD_MMC_H_
-  #if !defined(DISABLE_ALL_ESP32FOTA_LIBRARY_WARNINGS)
+  #if !defined(DISABLE_ALL_LIBRARY_WARNINGS)
   #pragma message "Using SD_MMC for certificate validation"
   #endif
   #include <SD_MMC.h>
   #define FOTA_FS &SD_MMC
 #elif defined _LIFFLEFS_H_ // older externally linked, hard to identify and unsupported versions of SPIFFS
-  #if !defined(DISABLE_ALL_ESP32FOTA_LIBRARY_WARNINGS)
+  #if !defined(DISABLE_ALL_LIBRARY_WARNINGS)
   #pragma message "this version of LittleFS is unsupported, use #include <LittleFS.h> instead, if using platformio add LittleFS(esp32)@^2.0.0 to lib_deps"
   #endif
 #elif __has_include(<PSRamFS.h>) || defined _PSRAMFS_H_
-  #if !defined(DISABLE_ALL_ESP32FOTA_LIBRARY_WARNINGS)
+  #if !defined(DISABLE_ALL_LIBRARY_WARNINGS)
   #pragma message "Using PSRamFS for certificate validation"
   #endif
   #include <PSRamFS.h>
   #define FOTA_FS &PSRamFS
 #else
-  //#if !defined(DISABLE_ALL_ESP32FOTA_LIBRARY_WARNINGS)
+  //#if !defined(DISABLE_ALL_LIBRARY_WARNINGS)
   // #pragma message "No filesystem provided, certificate validation will be unavailable (hint: include SD, SPIFFS or LittleFS before including this library)"
   //#endif
   #define FOTA_FS nullptr
@@ -226,6 +227,7 @@ struct FOTAConfig_t
   size_t       signature_len {FW_SIGNATURE_LENGTH};
   bool         allow_reuse { true };
   bool         use_http10 { false }; // Use HTTP 1.0 (WARNING: setting to 'true' disables chunked transfers)
+  bool         use_bundled_certs { false };   // use built-in ESP-IDF CA bundle
   FOTAConfig_t() = default;
 };
 
@@ -291,6 +293,10 @@ public:
   void setCertFileSystem( fs::FS *cert_filesystem = nullptr );
 
   // this is passed to Update.onProgress()
+
+  // enable bundled CA certificates
+  void useBundledCerts(bool enable = true);
+
   typedef std::function<void(size_t,size_t)> ProgressCallback_cb; // size_t progress, size_t size
   void setProgressCb(ProgressCallback_cb fn) { onOTAProgress = fn; } // callback setter
 
@@ -407,4 +413,3 @@ private:
   const char* root_ca_pem_default_path = "/root_ca.pem";
 
 };
-#endif // esp32fota_h

--- a/CheapoDC/CDCommands.cpp
+++ b/CheapoDC/CDCommands.cpp
@@ -163,8 +163,9 @@ cmdResponse getCmdProcessor(const String &var)
         LOG_INFO("processor", "--FILE: " << file.name() << " tSIZE: " << file.size());
         newResponse.response += String("<div class=\"filelist\"><fileItem>") + String(file.name()) + String("</fileItem><fileAction1>");
         newResponse.response += String(" <a href=\"./download?file=") + String(file.path()) + String("\" download=\"") + String(file.name()) + String("\">Download</a></fileAction1><fileAction2>");
-        newResponse.response += String("<div class=\"danger\" onclick=\"deleteFile('") + String(file.path()) + String("')\" >Delete</div></fileAction2></div></li>");
+        newResponse.response += String("<div class=\"danger\" onclick=\"deleteFile('") + String(file.path()) + String("')\" >Delete</div></fileAction2></div>");
       }
+      file.close();
       file = root.openNextFile();
     }
 

--- a/CheapoDC/CDController.cpp
+++ b/CheapoDC/CDController.cpp
@@ -32,7 +32,7 @@ dewController::dewController(void)
     this->_controllerPinSettings[CONTROLLER_PIN0].controllerPinMode = CONTROLLER_PIN_MODE_CONTROLLER;
 #endif // CDC_DEFAULT_CONTROLLER_PIN0
 #ifdef CDC_DEFAULT_CONTROLLER_PIN1
-    LOG_DEBUG("dewController", "Contorller Pin 1: " << CDC_DEFAULT_CONTROLLER_PIN1);
+    LOG_DEBUG("dewController", "Controller Pin 1: " << CDC_DEFAULT_CONTROLLER_PIN1);
 
     this->_controllerPinSettings[CONTROLLER_PIN1].controllerPinPin = CDC_DEFAULT_CONTROLLER_PIN1;
     this->_controllerPinSettings[CONTROLLER_PIN1].controllerPinMode = CONTROLLER_PIN_MODE_CONTROLLER;

--- a/CheapoDC/CheapoDC.ino
+++ b/CheapoDC/CheapoDC.ino
@@ -21,7 +21,6 @@ char programVersion[] = "2.3.1";  // program version
 
 CDCSetup *theSetup; // main setup class
 dewController *theDController;
-//ESP32Time *theTime;
 
 // Counters used for time based scheduler in main loop
 int milliCount = 0;

--- a/CheapoDC/CheapoDC.ino
+++ b/CheapoDC/CheapoDC.ino
@@ -17,7 +17,7 @@
 #endif
 
 char programName[] = "CheapoDC"; // Program name
-char programVersion[] = "2.3.0";  // program version
+char programVersion[] = "2.3.1";  // program version
 
 CDCSetup *theSetup; // main setup class
 dewController *theDController;

--- a/CheapoDC/README.md
+++ b/CheapoDC/README.md
@@ -114,7 +114,7 @@ The *Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)* partition scheme provides
 
 To allow for OTA updates, LittleFS storage and some expansion room for CheapoDC firmware the *Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)* partition scheme is used. Although this scheme provides enough application space it provides too little SPIFFS (data partition) space for the CheapoDC HTML, CSS and JS files without compression. The repository [**data source**](../data%20source/) folder contains he original source for these files. The repository [**CheapoDC/data**](../CheapoDC/data/) folder contains minified or compressed versions for installation in the LittleFS formatted data partition.
 
-### Setting Up Your Build Environment\
+### Setting Up Your Build Environment
 
 1. Install the Arduino IDE.  
   **NOTE:** Version 2.3.10 of the Arduino IDE is required. As of CheapoDC V2.3.1 verification of

--- a/CheapoDC/README.md
+++ b/CheapoDC/README.md
@@ -6,34 +6,40 @@ Go to the [WebFlash page](https://hcomet.github.io/CheapoDC/CheapoDCFlash.html) 
 
 If you prefer to build the firmware yourself using the Arduino IDE please continue on to [Building and Installing CheapoDC](#building-and-installing-cheapodc)
 
-Note that as of CheapoDC v2.2.0, the Web UI supports an semi-automatic web-based upgrade that preserves your configuration files. Web OTA Update while upgrading the firmware and data partitions. See the documentation on [Web OTA Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html) for details.
+Note that as of CheapoDC V2.2.0, the Web UI supports an semi-automatic web-based upgrade that preserves your configuration files. Web OTA Update while upgrading the firmware and data partitions. See the documentation on [Web OTA Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html) for details.
 
 # Building and installing CheapoDC
 
 ## If you are Upgrading from a Previous Release
 
-This note is to highlight the change in recommended partition scheme implemented for release v2.1.0. If you are upgrading from a release prior to v2.1.0 then you will need to switch partition schemes as part of the upgrade. Please read the [Partition Scheme](#partition-scheme) section for the reasons for the change.
+This note is to highlight the change in recommended partition scheme implemented for release V2.1.0. If you are upgrading from a release prior to V2.1.0 then you will need to switch partition schemes as part of the upgrade. Please read the [Partition Scheme](#partition-scheme) section for the reasons for the change. Unfortunately, upgrading from CheapDC 2.3.0 to 2.3.1 must be done using the Manual OTA Update in the Web UI, Device Management page.
 
 ## Changes in CheapoDC V2
 
-1. V2 contains changes to support new library versions:
-   * Arduino core for ESP32 version 3.1.x support. Core Version 2.x support now deprecated as of CheapoDC v2.1.0.
+1. As of V2.2.0, CheapDC now supports firmware and data partition upgrades using the Web UI and HTTP OTA. See the documentation on [Web OTA Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html) for details.  
+> [!IMPORTANT]
+> After the release of V2.3.0 (Nov. 2025) GitHub Pages changed the root CA for HTTPS causing Web OTA Update to stop working. V2.3.1 (June 2026) fixes Web OTA Update by using a new version of esp32FOTA, 0.3.0, which supports using the Mozilla trusted CA list as a CA bundle.
+2. V2 contains changes to support new library versions:
+   * Arduino core for ESP32 version 3.1.x support. Core Version 2.x support now deprecated as of CheapoDC V2.1.0.
    * Switch to the [ESP32 Asynchronous Networking Organization](https://github.com/ESP32Async) versions of
    ESPAsyncWebServer and AsyncTCP.
    * ArduinoJson version 7. Version 6 should also continue to work but migration to version 7 is encouraged.
-2. The following libraries are no longer required:
+3. New libraries required in V2:
+   * As of V2.3.0, [Sensirion Core by Sensirion](https://github.com/Sensirion/arduino-core/) and [Sensirion I²C SHT3X by Sensirion](https://github.com/Sensirion/arduino-i2c-sht3x) are required for humidity sensor support.
+   * As of V2.3.1, [ESP32CertBundle](https://github.com/tanakamasayuki/ESP32CertBundle) is required to support [Web OTA Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html).
+4. The following libraries are no longer required:
    * EasyLogger - a fixed copy of this library is included in the CheapoDC source to remove a macro definition conflict with ArduinoJSON.
    * ESP32Time.
-3. As of V2.2.0, all major items that were previously required to be configured at compile time can now be configured through the Web UI or API at runtime. This includes:
+5. As of V2.2.0, all major items that were previously required to be configured at compile time can now be configured through the Web UI or API at runtime. This includes:
    * [WiFi Configuration](../README.md#wifi-configuration): WiFi SSID and password can be set on the Device Management page.
    * Weather Source: The Weather Source may now be set through the Web UI or API. Open-Meteo is now the default Weather Source.
    * [Output to GPIO Pin mapping](../README.md#controller-output-configuration). All controller outputs may be configured using the Web UI or API. This includes the original two core dew controller outputs as well as the four new additional outputs added in V2.2.0.
    * [Status LED GPIO Pin](../README.md#status-led-configuration). The pin used for the status LED as well as whether or not it is active High or Low may be configured through the Web UI or API.
    * [Change Password](../README.md#change-password). The user Id remains **admin** but the password may now be changed in the Web UI. Password security has been improved by moving to using a [Digest access authentication](https://en.wikipedia.org/wiki/Digest_access_authentication#:~:text=In%20contrast%2C%20basic%20access%20authentication,It%20uses%20the%20HTTP%20protocol.) MD5 Password Hash.
-4. New Weather Sources added for more flexibility and autonomous operation:
+6. New Weather Sources added for more flexibility and autonomous operation:
    * V2.2.0 added support for integration with personal weather stations or other weather services. When the Weather Source is set to ***External Source*** the local ambient temperature and humidity may be set through the API. The Dew Point and dew controller power output will then be calculated based on these externally set values.
    * V2.3.0 added support for connecting an SHT3x humidity/temperature sensor. When the Weather Source is set to ***Internal Source***, local ambient temperature and humidty will be taken from a temperature/humidity sensor connected to the CheapoDC. The SHT3x must be properly [connected and configured](https://hcomet.github.io/CheapoDC/CheapoDCSensor.html) for ***Internal Source*** to work.
-5. API changes:
+7. API changes:
    * ***`CPPx`***, ***`CPMx`*** and ***`CPOx`*** API commands added to allow outputs **x = 0 to 5** to be configured for GPIO Pin mapping, Output Mode and Output Power respectively.
    * The ***`LED`*** API command changed to set the GPIO pin for the Status LED while ***`LEDH`*** sets the value of High to 1 or 0.
    * The Weather Source (***`WS`***) API command now supports a SET capability. This API command has also been changed
@@ -46,22 +52,22 @@ This note is to highlight the change in recommended partition scheme implemented
    * The Weather API URL (***`WAPI`***) API command no longer supports a SET capability.
    * The Weather Icon URL (***`WIURL`***) API command no longer supports a SET capability.
    * The Cloud Coverage (***`CLC`***) API command has been deprecated.
-6. Support for the Web Sockets based API has been deprecated and removed in V2.2.0. The TCP API continues to be supported and used by the INDI driver.
-7. CheapoDC V2 will automatically upgrade the CDCConfig.json on your CheapoDC device when the new firmware version is installed. Previous configuration settings will be maintained. Follow the [Upgrade Steps](#upgrading-from-a-previous-release) below to preserve your
+8. Support for the Web Sockets based API has been deprecated and removed in V2.2.0. The TCP API continues to be supported and used by the INDI driver.
+9. CheapoDC V2 will automatically upgrade the CDCConfig.json on your CheapoDC device when the new firmware version is installed. Previous configuration settings will be maintained. Follow the [Upgrade Steps](#upgrading-from-a-previous-release) below to preserve your
 CheapoDC configuration files.
-8. Change in ESP32 Partition Scheme required for CheapoDC V2.1.x. See [Partition Scheme](#partition-scheme) for details.
-9. As of V2.2.0, CheapDC now supports firmware and data partition upgrades using the Web UI and HTTP OTA. See the documentation on [Web OTA Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html) for details.
-10. As of V2.3.0, when in Access Point Mode, CheapoDC will use the hostname for the SSID.
-11. See the CheapoDC [release notes](https://github.com/hcomet/CheapoDC/releases) for additional details.
+10. Change in ESP32 Partition Scheme required for CheapoDC V2.1.x. See [Partition Scheme](#partition-scheme) for details.
+
+11. As of V2.3.0, when in Access Point Mode, CheapoDC will use the hostname for the SSID.
+12. See the CheapoDC [release notes](https://github.com/hcomet/CheapoDC/releases) for additional details.
 
 ## Setting Up Your Build Environment
 
 1. Install the Arduino IDE.  
-  <u>**NOTE:**</u> Version 2.3.6 of the Arduino IDE is required. As of CheapoDC v2.3.0 verification of
-  builds will only be done on IDE version 2.3.6 or newer.
+  <u>**NOTE:**</u> Version 2.3.8 of the Arduino IDE is required. As of CheapoDC V2.3.1 verification of
+  builds will only be done on IDE version 2.3.8 or newer.
 2. Add support for ESP32 modules using the Boards Manager in the Arduino IDE.  
   <u>**IMPORTANT:**</u>
-    * Install the boards plugin for ESP32 from Espressif Systems version 3.3.2 (Arduino core for the ESP32). CheapoDC verification has been done with version 3.3.2. (Note: 3.3.0 and 3.3.1 seemed to have some issues with WiFi connectivity so neither are recommended.)
+    * Install the boards plugin for ESP32 from Espressif Systems version 3.3.8 (Arduino core for the ESP32). CheapoDC V2.3.1 verification has been done with version 3.3.8.
     * CheapoDC is intended for use on ESP32 devices. The current version has been verified on an [ESP32-C3 SuperMini](https://michiel.vanderwulp.be/domotica/Modules/ESP32-C3-SuperMini/) board..
 3. Install the ESP32 Sketch data uploader with support for LittleFS. The CheapoDC uses the LittleFS file system for configuration files and web pages uploaded from the ***CheapoDC/data*** folder. If the data is uploaded using any other file system format, such as SPIFFS, the CheapoDC firmware will not run properly.  
 <u>**NOTE:**</u> The following link provides information on how to install a data uploader plugin with LittleFS support:
@@ -69,22 +75,24 @@ CheapoDC configuration files.
 
 4. Install the following libraries if not already installed:
    * [ArduinoJson by Benoit Blanchon](https://arduinojson.org/)  
-     Version: 7.4.2
+     Version: 7.4.3
    * [ESP Async WebServer by ESP32Async](https://github.com/ESP32Async/ESPAsyncWebServer)  
-     Version: 3.8.1
+     Version: 3.11.0
    * [Async TCP by ESP32Async](https://github.com/ESP32Async/AsyncTCP)  
-     Version: 3.4.9
+     Version: 3.4.10
    * [Sensirion I²C SHT3X by Sensirion](https://github.com/Sensirion/arduino-i2c-sht3x)  
      Version 1.0.1
    * [Sensirion Core by Sensirion](https://github.com/Sensirion/arduino-core/)  
-     Version 0.7.2
+     Version 0.7.3
    * [Time by Michael Margolis](https://playground.arduino.cc/Code/Time/)  
      Version: 1.6.1
+   * [ESP32CertBundle](https://github.com/tanakamasayuki/ESP32CertBundle)  
+     Version: 20260514.0.0
 
    <u>**NOTES:**</u>
-   * CheapoDC v2.1.0 has migrated from the [dvarrel](https://github.com/dvarrel) versions of EspAsyncWebServer and AsyncTCP to the [ESP32Async Organization](https://github.com/ESP32Async) versions. ESP32Async Organization looks to be very proactive in maintaining the libraries and also contains members of the Arduino core for ESP32 team helping to keep it in sync. Currently the Arduino Library Manager shows Me-No-Dev as the owner but will likely change to ESP32Async.
+   * CheapoDC V2.1.0 has migrated from the [dvarrel](https://github.com/dvarrel) versions of EspAsyncWebServer and AsyncTCP to the [ESP32Async Organization](https://github.com/ESP32Async) versions. ESP32Async Organization looks to be very proactive in maintaining the libraries and also contains members of the Arduino core for ESP32 team helping to keep it in sync. Currently the Arduino Library Manager shows Me-No-Dev as the owner but will likely change to ESP32Async.
    * If you have other versions of the ESPSyncWebServer or AsyncTCP not from the links above they will need to be uninstalled to prevent issues with the build.
-   * In general, if newer versions of a library are available then only use new subversions not new major versions.
+   * In general, if newer versions of a library are available then only use new subversions not new major versions. CheapoDC v2.3.1 was verified using the versions of libraries listed above.
 
 5. Download the latest firmware release source code from <https://github.com/hcomet/CheapoDC/releases>  
   <u>**NOTE:**</u> After extracting the release to your file system open the CheapoDC.ino file in the Arduino IDE. This will open the full set of source files in the IDE. Now configure the firmware before building it.
@@ -172,7 +180,7 @@ Your CheapoDC should now be ready to use.
 
 ## Upgrading from a previous release
 
-Note that v2.1.0 required a change in the [Partition Scheme](#partition-scheme) and upgrades from a pre-V2.1.0 release must be done using a USB connection to the device.
+Note that V2.1.0 required a change in the [Partition Scheme](#partition-scheme) and upgrades from a pre-V2.1.0 release must be done using a USB connection to the device.
 
 New versions of ESPAsyncWebServer and AsyncTCP libraries are also required for Arduino core of ESP32 version 3.1.x. Please read the [Setting Up Your Build Environment](#setting-up-your-build-environment) section to make sure you have the correct libraries installed in the Arduino IDE. Be sure to have only one version of the AsyncTCP library installed.
 
@@ -191,22 +199,31 @@ Place both files in the sketch data folder: ***CheapoDC/data***.
 
 ### OTA Upgrade using the Web UI Firmware Update
 
-If upgrading from a release prior to v2.1.0, an OTA firmware upgrade cannot be used. Go back to the [USB connected upgrade](#upgrade-using-usb-connected-device).
+If upgrading from a release prior to V2.1.0, an OTA firmware upgrade cannot be used. Go back to the [USB connected upgrade](#upgrade-using-usb-connected-device).
 
 If upgrading from V2.1.0 or newer then use **Manual Update** on the Web UI [Device Management](../README.md#cheapodc-device-management) page.
 
 #### Web OTA Update
 
-Introduced in the V2.2.0 release, [Web OTA Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html) which makes upgrades simple and easy.
+Introduced in the V2.2.0 release, [Web OTA Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html) which makes upgrades simple and easy.  
+>[!IMPORTANT]
+> Due to a change to the issuing CA for GitHub Pages HTTPS certificate upgrading from V2.3.0 or earlier must be done using Manual OTA Update. V2.3.1 fixes the issue.
 
 #### Manual OTA Update
 
-If you have firmware without Web OTA Update support or you prefer to do your own builds and updates then:
+Manual OTA Update allows you to do an OTA update using your own copy of the CheapoDC firmware binary image. Use the following steps:
 
-* Generate the firmware binary image using the Arduino IDE and selecting `Sketch->Export Compiled Binary`. This will create a ***CheapoDC.ino.bin*** file under a ***build*** folder created in your sketch folder.
-* Use the **Manual OTA Update** `Choose File` in the Web UI to select the new bin file. Then click `Update` to flash the CheapoDC to the new version.
-* After the reboot, go to the [File Management](../README.md#cheapodc-file-management) page to upload the new release data files. Use `Choose Files` to browse to the ***CheapoDC/data*** folder in your sketch folder. Then select all files **EXCEPT** the CDCWiFi.json file. Then click `Upload`.
-* Your upgrade should now be complete.
+1. Download the latest firmware release source code from <https://github.com/hcomet/CheapoDC/releases> and extract it to your local file system.
+2. Get or generate the firmware binary image file by either:
+
+   * Downloading the latest CheapoDC binary image file from [https://hcomet.github.io/CheapoDC/firmware/CheapoDC.ESP32-C3.bin](https://hcomet.github.io/CheapoDC/firmware/CheapoDC.ESP32-C3.bin).
+   * Generating the firmware binary image using the Arduino IDE and selecting `Sketch->Export Compiled Binary`. This will create a ***CheapoDC.ino.bin*** file under a ***build*** folder created in your sketch folder.  
+     > [!NOTE]
+     > Follow the instructions in [Build and Install the Firmware](#build-and-install-the-firmware) to set up the Arduino IDE for CheapoDC builds.
+
+3. Use the **Manual OTA Update** `Choose File` in the Web UI to select the ***.bin*** file from step 2. Then click `Update` to flash the CheapoDC to the new version.
+4. After the reboot, go to the [File Management](../README.md#cheapodc-file-management) page to upload the new release data files. Use `Choose Files` to browse to the ***CheapoDC/CheapoDC/data*** folder in the downloaded release from step 1. Then select all files **EXCEPT** the CDCWiFi.json file. Then click `Upload`.
+5. Your upgrade should now be complete.
 
 ## Configuration Files
 
@@ -255,12 +272,12 @@ The *Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)* partition scheme provides
 3. The other predefined partition schemes didn't provide a good option for larger application size, OTA support and a partition large enough for the LittleFS data CheapoDC needed.
 
 It turns out that I was wrong about the second point. Although I have not added a lot of code to the initial version of CheapoDC the underlying libraries it relies on have changed and expanded in size. A combination of moving to the Arduino core for ESP32 3.1.x,
-Arduino 2.3.x, adopting the ESPAsync Organization version of ESPAsync Web Server plus other new library releases has put the CheapoDC v2.1.0 release at 98.6% of the application space. This is without Debug logging or WebSockets support enabled, which can no longer be enabled.
+Arduino 2.3.x, adopting the ESPAsync Organization version of ESPAsync Web Server plus other new library releases has put the CheapoDC V2.1.0 release at 98.6% of the application space. This is without Debug logging or WebSockets support enabled, which can no longer be enabled.
 
-The only solution is to move to a different partition scheme starting with CheapoDC release v2.1.0. As of v2.1.0 the recommended partition scheme is *Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)*. This scheme should hopefully provide plenty of application space going forward. The basic configuration of CheapoDC v2.1.0 takes 62% of the available space. In order to fit in the smaller SPIFFS partition the HTML, CSS and JS files used by CheapoDC have been run through a minimizer and additional compression applied to the PNG images.
+The only solution is to move to a different partition scheme starting with CheapoDC release V2.1.0. As of V2.1.0 the recommended partition scheme is *Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)*. This scheme should hopefully provide plenty of application space going forward. The basic configuration of CheapoDC V2.1.0 takes 62% of the available space. In order to fit in the smaller SPIFFS partition the HTML, CSS and JS files used by CheapoDC have been run through a minimizer and additional compression applied to the PNG images.
 
 ### Impact of the change in Partition Scheme
 
 If this is your first time building the CheapoDC then you are not affected. The [new device build instructions](#build-and-configure-a-new-device) still apply.
 
-If you are upgrading to v2.1.x from a release prior to v2.1.0 then you are affected. Read and follow the [upgrading from a previous release](#upgrading-from-a-previous-release) instructions.
+If you are upgrading to V2.1.x from a release prior to V2.1.0 then you are affected. Read and follow the [upgrading from a previous release](#upgrading-from-a-previous-release) instructions.

--- a/CheapoDC/README.md
+++ b/CheapoDC/README.md
@@ -1,28 +1,78 @@
 # Installing CheapoDC
 
-## WebFlash, the Easy Option
+## WebFlash, the Easy Option for New Devices
 
-If you are using an [ESP32-C3 SuperMini](https://michiel.vanderwulp.be/domotica/Modules/ESP32-C3-SuperMini/) or any other ESP32-C3 module then the easiest way to load the CheapoDC firmware onto your device is to use [WebFlash](https://hcomet.github.io/CheapoDC/CheapoDCFlash.html). All other configuration can then be done through the [Web UI](../README.md#web-ui). WebFlash is primarily for new installs but you can also use it to upgrade your CheapoDC to the latest firmware. Details in the [Upgrading from a Previous Release](#2-upgrade-using-usb-connected-device-and-webflash) section.
+If you are using an [ESP32-C3 SuperMini](https://michiel.vanderwulp.be/domotica/Modules/ESP32-C3-SuperMini/) or any other ESP32-C3 module then the easiest way to load the CheapoDC firmware onto your device is to use [WebFlash](https://hcomet.github.io/CheapoDC/CheapoDCFlash.html). All necessary configuration changes may then be done through the [Web UI](../README.md#web-ui). 
 
-You need to connect your ESP32-C3 to your computer via USB to use WebFlash. Go to the [WebFlash page](https://hcomet.github.io/CheapoDC/CheapoDCFlash.html) to install CheapoDC on your ESP32-C3. Then follow the instructions bellow in the [First Time Device Configuration](#first-time-device-configuration) section.
+You need to connect your ESP32-C3 to your computer via USB to use WebFlash. Go to the [WebFlash page](https://hcomet.github.io/CheapoDC/CheapoDCFlash.html) to install CheapoDC on your ESP32-C3. Then follow the instructions below in the [First Time Device Configuration](#first-time-device-configuration) section.
 
-
-
-If you prefer to build the firmware yourself using the Arduino IDE please continue on to [Building and Installing CheapoDC](#building-and-installing-cheapodc)
+If you prefer to build the firmware yourself using the Arduino IDE, please continue to [Building and Installing CheapoDC](#building-and-installing-CheapoDC)
 
 >[NOTE!]
 >CheapoDC V2.2.0 added Web UI support for a semi-automatic web-based upgrade that preserves your configuration files. See the documentation on [Web OTA Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html) for details.
 
+## Upgrading from a Previous Release
+
+There are four methods described below for upgrading CheapoDC firmware. Two leverage Over-the-air (OTA) update methods while the other two methods require a computer and USB connection to the device.
+
+### 1. Web OTA Update
+
+Introduced in the V2.2.0 release, [Web OTA Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html) is the simple and easy way to upgrade your CHeapoDC firmware. When a new release is available it will be indicated in the **Web OTA Update**
+section on the **Device Management** page of the CheapoDC WebUI. Just enter your CheapoDC password, click `Update` and the new release will be installed while preserving your CheapoDC configuration files.
+
+>[!IMPORTANT]
+> Due to a change to the issuing CA for GitHub Pages HTTPS certificates, Web OTA Update from V2.3.0 or earlier no longer works. One of the other upgrade methods must be used to update to V2.3.1 or newer. V2.3.1 fixes the issue and Web OTA Update should work properly from that version onwards.
+>
+> Go to the section [***Web OTA Root CA Issue***](#web-ota-root-ca-issue) for details on how to get Web OTA Update to detect a new release and perform the firmware update from V2.2.0 or V2.3.0.
+
+
+### 2. Manual OTA Update
+
+Manual OTA Update allows you to do an OTA update using your own copy of the CheapoDC firmware binary image. Use the following steps:
+
+1. Download the latest firmware release source code from <https://github.com/hcomet/CheapoDC/releases> and extract it to your local file system.
+2. Get or generate the firmware binary image file by either:
+
+   1. Downloading the latest CheapoDC binary image file from [https://hcomet.github.io/CheapoDC/firmware/CheapoDC.ESP32-C3.bin](https://hcomet.github.io/CheapoDC/firmware/CheapoDC.ESP32-C3.bin).
+   2. Or generating the firmware binary image using the Arduino IDE and selecting `Sketch->Export Compiled Binary`. This will create a ***CheapoDC.ino.bin*** file under a ***build*** folder created in your sketch folder.  
+   **Note:** Follow the instructions in [Build and Install the Firmware](#build-and-install-the-firmware) to set up the Arduino IDE for CheapoDC builds.
+
+3. Use the **Manual OTA Update** `Choose File` in the Web UI to select the ***.bin*** file from step 2. Then click `Update` to flash the CheapoDC to the new version.
+4. After the reboot, go to the [File Management](../README.md#CheapoDC-file-management) page to upload the new release data files. Use `Choose Files` to browse to the ***CheapoDC/CheapoDC/data*** folder in the downloaded release from step 1. Then select all files **EXCEPT** the CDCWiFi.json file. Then click `Upload`.
+5. Your upgrade should now be complete.
+
+
+### 3. Upgrade using USB Connected Device and Arduino IDE
+
+1. Preserve your current CheapoDC configuration and WiFi settings by first downloading the CDCConfig.json and CDCWiFi.json files
+from your CheapoDC. This can be done using the Web UI from the [File Management](../README.md#CheapoDC-file-management) page.
+Place both files in the sketch data folder: ***CheapoDC/data***.
+2. Build and upload the new firmware to your device.
+   * If upgrading from a pre-V2.1.0 release, make sure to set *Erase All Flash Before Sketch Upload:* ***"Enabled"***  
+   **NOTE:** Make sure to reset this to **"Disabled"** once you are done with the upgrade or the LittleFS partition will be erased with each
+   firmware upload and you will need to upload your sketch data every time.
+   * Make sure to have selected the *Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)* partition scheme.
+3. Upload the files in the CheapoDC/data folder using the Sketch data uploading tool. Make sure to use an upload tool for the LittleFS filesystem.
+4. Your upgrade should now be complete.
+
+### 4. Upgrade using USB Connected Device and WebFlash
+
+1. WebFlash will erase all flash memory on your CheapoDC. You must backup your current CheapoDC configuration and WiFi settings by first downloading the **CDCConfig.json** and **CDCWiFi.json** files
+from your CheapoDC. This can be done using the Web UI from the [File Management](../README.md#CheapoDC-file-management) page.
+2. Use [WebFlash](https://hcomet.github.io/CheapoDC/CheapoDCFlash.html) to install the latest CheapoDC firmware onto your device.
+3. Once the device has rebooted, it will be in access point mode. Use your computer to connect to the access point, SSID: CheapoDC and Password: CheapoDC.
+4. Browse to the CheapoDC Web UI at [http://CheapoDC.local](http://CheapoDC.local) and login using the default userid and password: admin, admin.
+5. Upload the previously backed up **CDCConfig.json** and **CDCWifi.json** files using the File Management page.
+5. Goto to the Device Management page and reboot the device to complete the upgrade.
+
 ## Changes in CheapoDC V2
 
-1. As of V2.2.0, CheapDC now supports firmware and data partition upgrades using the Web UI and HTTP OTA. See the documentation on [Web OTA Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html) for details.  
-> [!IMPORTANT]
-> After the release of V2.3.0 (Nov. 2025) GitHub Pages changed the root CA for HTTPS causing Web OTA Update to stop working. V2.3.1 (June 2026) fixes Web OTA Update by using a new version of esp32FOTA, 0.3.0, which supports using the Mozilla trusted CA list as a CA bundle.
+1. As of V2.2.0, CheapoDC now supports firmware and data partition upgrades using the Web UI and HTTP OTA. See the documentation on [Web OTA Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html) for details.
 2. V2 contains changes to support new library versions:
-   * Arduino core for ESP32 version 3.1.x support. Core Version 2.x support now deprecated as of CheapoDC V2.1.0.
+   * Arduino core for ESP32 version 3.x support. Core Version 2.x support now deprecated as of CheapoDC V2.1.0.
    * Switch to the [ESP32 Asynchronous Networking Organization](https://github.com/ESP32Async) versions of
    ESPAsyncWebServer and AsyncTCP.
-   * ArduinoJson version 7. Version 6 should also continue to work but migration to version 7 is encouraged.
+   * ArduinoJson version 7.x.
 3. New libraries required in V2:
    * As of V2.3.0, [Sensirion Core by Sensirion](https://github.com/Sensirion/arduino-core/) and [Sensirion I²C SHT3X by Sensirion](https://github.com/Sensirion/arduino-i2c-sht3x) are required for humidity sensor support.
    * As of V2.3.1, [ESP32CertBundle](https://github.com/tanakamasayuki/ESP32CertBundle) is required to support [Web OTA Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html).
@@ -33,11 +83,11 @@ If you prefer to build the firmware yourself using the Arduino IDE please contin
    * [WiFi Configuration](../README.md#wifi-configuration): WiFi SSID and password can be set on the Device Management page.
    * Weather Source: The Weather Source may now be set through the Web UI or API. Open-Meteo is now the default Weather Source.
    * [Output to GPIO Pin mapping](../README.md#controller-output-configuration). All controller outputs may be configured using the Web UI or API. This includes the original two core dew controller outputs as well as the four new additional outputs added in V2.2.0.
-   * [Status LED GPIO Pin](../README.md#status-led-configuration). The pin used for the status LED as well as whether or not it is active High or Low may be configured through the Web UI or API.
+   * [Status LED GPIO Pin](../README.md#status-led-configuration). The pin used for the status LED as well as whether it is active High or Low may be configured through the Web UI or API.
    * [Change Password](../README.md#change-password). The user Id remains **admin** but the password may now be changed in the Web UI. Password security has been improved by moving to using a [Digest access authentication](https://en.wikipedia.org/wiki/Digest_access_authentication#:~:text=In%20contrast%2C%20basic%20access%20authentication,It%20uses%20the%20HTTP%20protocol.) MD5 Password Hash.
 6. New Weather Sources added for more flexibility and autonomous operation:
    * V2.2.0 added support for integration with personal weather stations or other weather services. When the Weather Source is set to ***External Source*** the local ambient temperature and humidity may be set through the API. The Dew Point and dew controller power output will then be calculated based on these externally set values.
-   * V2.3.0 added support for connecting an SHT3x humidity/temperature sensor. When the Weather Source is set to ***Internal Source***, local ambient temperature and humidty will be taken from a temperature/humidity sensor connected to the CheapoDC. The SHT3x must be properly [connected and configured](https://hcomet.github.io/CheapoDC/CheapoDCSensor.html) for ***Internal Source*** to work.
+   * V2.3.0 added support for connecting an SHT3x humidity/temperature sensor. When the Weather Source is set to ***Internal Source***, local ambient temperature and humidity will be taken from a temperature/humidity sensor connected to the CheapoDC. The SHT3x must be properly [connected and configured](https://hcomet.github.io/CheapoDC/CheapoDCSensor.html) for ***Internal Source*** to work.
 7. API changes:
    * ***`CPPx`***, ***`CPMx`*** and ***`CPOx`*** API commands added to allow outputs **x = 0 to 5** to be configured for GPIO Pin mapping, Output Mode and Output Power respectively.
    * The ***`LED`*** API command changed to set the GPIO pin for the Status LED while ***`LEDH`*** sets the value of High to 1 or 0.
@@ -54,10 +104,8 @@ If you prefer to build the firmware yourself using the Arduino IDE please contin
 8. Support for the Web Sockets based API has been deprecated and removed in V2.2.0. The TCP API continues to be supported and used by the INDI driver.
 9. CheapoDC V2 will automatically upgrade the CDCConfig.json on your CheapoDC device when the new firmware version is installed. Previous configuration settings will be maintained. Follow the [Upgrade Steps](#upgrading-from-a-previous-release) below to preserve your
 CheapoDC configuration files.
-10. Change in ESP32 Partition Scheme required for CheapoDC V2.1.x. See [Partition Scheme](#partition-scheme) for details.
-
-11. As of V2.3.0, when in Access Point Mode, CheapoDC will use the hostname for the SSID.
-12. See the CheapoDC [release notes](https://github.com/hcomet/CheapoDC/releases) for additional details.
+10. As of V2.3.0, when in Access Point Mode, CheapoDC will use the hostname for the SSID.
+11. See the CheapoDC [release notes](https://github.com/hcomet/CheapoDC/releases) for additional details.
 
 ## Building and Installing CheapoDC
 
@@ -67,17 +115,17 @@ The ESP32 Partition Scheme is a term used by the Arduino IDE to select a partiti
 
 The *Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)* partition scheme provides two application partitions of 1.2MB to support OTA updates plus a 1.5MB SPIFFS partition used for LittleFS file storage. The latest version of CheapoDC using the latest Arduino library versions requires about 1.6MB of application space.
 
-To allow for OTA updates, LittleFS storage and some expansion room for CheapoDC firmware the *Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)* partition scheme is used. This scheme provides too little space for the CheapoDC HTML, CSS and JS files without compression. The repository [**data source**](../data%20source/) folder contains he original source for these files. The repository [**CheapoDC/data**](../CheapoDC/data/) folder contains minified or compressed versions for installation in the LittleFS formatted data partition.
+To allow for OTA updates, LittleFS storage and some expansion room for CheapoDC firmware the *Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)* partition scheme is used. Although this scheme provides enough application space it provides too little SPIFFS (data partition) space for the CheapoDC HTML, CSS and JS files without compression. The repository [**data source**](../data%20source/) folder contains he original source for these files. The repository [**CheapoDC/data**](../CheapoDC/data/) folder contains minified or compressed versions for installation in the LittleFS formatted data partition.
 
 ### Setting Up Your Build Environment
 
 1. Install the Arduino IDE.  
-  **NOTE:** Version 2.3.8 of the Arduino IDE is required. As of CheapoDC V2.3.1 verification of
-  builds will only be done on IDE version 2.3.8 or newer.
+  **NOTE:** Version 2.3.10 of the Arduino IDE is required. As of CheapoDC V2.3.1 verification of
+  builds will only be done on IDE version 2.3.10 or newer.
 2. Add support for ESP32 modules using the Boards Manager in the Arduino IDE.  
   **IMPORTANT:**
-    * Install the boards plugin for ESP32 from Espressif Systems version 3.3.8 (Arduino core for the ESP32). CheapoDC V2.3.1 verification has been done with version 3.3.8.
-    * CheapoDC is intended for use on ESP32 devices. The current version has been verified on an [ESP32-C3 SuperMini](https://michiel.vanderwulp.be/domotica/Modules/ESP32-C3-SuperMini/) board..
+    * Install the boards plugin for ESP32 from Espressif Systems version 3.3.10 (Arduino core for the ESP32). CheapoDC V2.3.1 verification has been done with version 3.3.10.
+    * CheapoDC is intended for use on ESP32 devices. The current version has been verified on an [ESP32-C3 SuperMini](https://michiel.vanderwulp.be/domotica/Modules/ESP32-C3-SuperMini/) board.
 3. Install the ESP32 Sketch data uploader with support for LittleFS. The CheapoDC uses the LittleFS file system for configuration files and web pages uploaded from the ***CheapoDC/data*** folder. If the data is uploaded using any other file system format, such as SPIFFS, the CheapoDC firmware will not run properly.  
 **NOTE:** The following link provides information on how to install a data uploader plugin with LittleFS support:
     * Arduino IDE 2.3.2+: [https://randomnerdtutorials.com/arduino-ide-2-install-esp32-littlefs/](https://randomnerdtutorials.com/arduino-ide-2-install-esp32-littlefs/)
@@ -86,7 +134,7 @@ To allow for OTA updates, LittleFS storage and some expansion room for CheapoDC 
    * [ArduinoJson by Benoit Blanchon](https://arduinojson.org/)  
      Version: 7.4.3
    * [ESP Async WebServer by ESP32Async](https://github.com/ESP32Async/ESPAsyncWebServer)  
-     Version: 3.11.0
+     Version: 3.11.1
    * [Async TCP by ESP32Async](https://github.com/ESP32Async/AsyncTCP)  
      Version: 3.4.10
    * [Sensirion I²C SHT3X by Sensirion](https://github.com/Sensirion/arduino-i2c-sht3x)  
@@ -95,7 +143,7 @@ To allow for OTA updates, LittleFS storage and some expansion room for CheapoDC 
      Version 0.7.3
    * [Time by Michael Margolis](https://playground.arduino.cc/Code/Time/)  
      Version: 1.6.1
-   * [ESP32CertBundle](https://github.com/tanakamasayuki/ESP32CertBundle)  
+   * [ESP32CertBundle by TANAKA Masayuki](https://github.com/tanakamasayuki/ESP32CertBundle)  
      Version: 20260514.0.0
 
    **NOTES:**
@@ -103,7 +151,7 @@ To allow for OTA updates, LittleFS storage and some expansion room for CheapoDC 
    * In general, if newer versions of a library are available then only use new subversions not new major versions. CheapoDC v2.3.1 was verified using the versions of libraries listed above.
 
 5. Download the latest firmware release source code from <https://github.com/hcomet/CheapoDC/releases>  
-  **NOTE:** After extracting the release to your file system open the CheapoDC.ino file in the Arduino IDE. This will open the full set of source files in the IDE. Now configure the firmware before building it.
+  **NOTE:** After extracting the release to your filesystem open the CheapoDC.ino file in the Arduino IDE. This will open the full set of source files in the IDE. Now configure the firmware before building it.
 
 >[!TIP]
 >* Many ESP32-C3 board configurations (Dev Module, mini, super mini, micro etc..) have *USB CDC On BOOT:* ***"Disabled"***. This needs to be ***"ENABLED"*** or the Serial Monitor will not work.
@@ -112,7 +160,7 @@ To allow for OTA updates, LittleFS storage and some expansion room for CheapoDC 
 
 ### Configure Firmware in the CDCdefines.h file
 
-As of V2.2.0 changes to the ***CDCdefines.h*** file are **not** required since all key items can now be modified at runtime, via the [WebUI](../README.md#web-ui), and are saved to the [CDCConfig.json](#cdcconfigjson). If you do wish to to configure/customize the firmware before building the following items may be modified in the ***CDCdefines.h*** file:
+As of V2.2.0 changes to the ***CDCdefines.h*** file are **not** required since all key items can now be modified at runtime, via the [WebUI](../README.md#web-ui), and are saved to the [CDCConfig.json](#cdcconfigjson). If you do wish to configure/customize the firmware before building the following items may be modified in the ***CDCdefines.h*** file:
 
 1. Set the default ESP32 GPIO pins to be used for Controller Outputs 0 & 1. ***DEFAULT: 0 & 1***.  
     ```#define CDC_DEFAULT_CONTROLLER_PIN0 0```  
@@ -127,11 +175,11 @@ As of V2.2.0 changes to the ***CDCdefines.h*** file are **not** required since a
     **NOTE:** Some ESP32-C3 modules have the Status LED wired so that setting the status pin high is off or reversed. Uncomment this line to reverse the High/Low setting for the status LED pin.  
     ```//#define CDC_REVERSE_HIGH_LOW```  
     *May be changed through the Web UI or API*
-4. Set up the WiFi configuration.  The CheapoDC may operate in either Access Point (AP) mode or Station (ST) mode. The CheapoDC defaults to AP mode when it cannot connect to an access point.  The AP mode SSID will be set to be the same as the hostname which defaults to ***cheapodc***.  
+4. Set up the WiFi configuration.  The CheapoDC may operate in either Access Point (AP) mode or Station (ST) mode. The CheapoDC defaults to AP mode when it cannot connect to an access point.  The AP mode SSID will be set to be the same as the hostname which defaults to ***CheapoDC***.  
 **NOTE:** Changing the WiFi configuration is **NOT** recommended. ST Mode settings can be changed in the Web UI while AP Mode settings will be overwritten if Web OTA Update is used.
     * AP Mode settings must be configured in the ***CDCdefines.h*** file:  
-      * Change AP mode password. ***DEFAULT: cheapodc***.  
-        ```#define CDC_DEFAULT_WIFI_AP_PASSWORD "cheapodc"```  
+      * Change AP mode password. ***DEFAULT: CheapoDC***.  
+        ```#define CDC_DEFAULT_WIFI_AP_PASSWORD "CheapoDC"```  
     * ST Mode settings may be configured in either the ***CDCdefines.h*** file or the ***CDCWiFi.json*** file found in the ***data*** folder. Values in found in the ***CDCWiFi.json*** files will be used before using the values in the ***CDCdefines.h*** file. Using the ***CDCWiFi.json*** file to configure WiFi access allows multiple APs and credentials to be defined. How to configure the ***CDCWiFi.json*** file is found [here](#cdcwifijson) while configuring default values in the ***CDCdefines.h*** file is as follows:
       * Change ST mode SSID. ***DEFAULT: defaultSSID***.  
         ```#define CDC_DEFAULT_WIFI_SSID "defaultSSID"```  
@@ -142,19 +190,21 @@ As of V2.2.0 changes to the ***CDCdefines.h*** file are **not** required since a
         ```//#define CDC_ENABLE_WIFI_TX_POWER_MOD WIFI_POWER_8_5dBm```  
         Uncomment to enable. If enabled the default value sets TX power to 8.5dbm. Any of the `wifi_power_t` values found [here](https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFi/src/WiFiGeneric.h#L51-L67) may be used. Extensive testing with WiFi TX Power settings has **NOT** been done.
 
-5. The hostname for the CheapoDC may also be changed. Its recommended that this be done using the [Web UI](../README.md#wifi-configuration). This is really only needed if you have multiple CheapoDC controllers on the same network.  To change the hostname in the ***CDCdefines.h*** file:  
-<br>**NOTE:** When in access point (AP) mode the SSID for the AP will be the same as the hostname.
-    * Change the host name. ***DEFAULT: cheapodc***.  
-      ```#define CDC_DEFAULT_HOSTNAME "cheapodc"```  
-      *Recommended to be modified only through the Web UI or API*
+5. The hostname for the CheapoDC may also be changed. Its recommended that this be done using the [Web UI](../README.md#wifi-configuration). This is only needed if you have multiple CheapoDC controllers on the same network. The default hostname in the ***CDCdefines.h*** file may be modified but it will be  by any hostname value in the [***CDCWiFi.json***](#cdcwifijson) file.: 
+    * Change the default host name. ***DEFAULT: CheapoDC***.  
+      ```#define CDC_DEFAULT_HOSTNAME "CheapoDC"```
+
+>[!NOTE]
+>When in access point (AP) mode the SSID for the AP will be the same as the hostname.
+
 6. As of firmware V2.2.0, CheapoDC supports a [Web Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html) capability. This is enabled by default but can be disabled by commenting out the following line:  
     ```#define CDC_ENABLE_HTTP_OTA```
-7. Do not modify any of the ```#define``` values below the line  ```DO NOT change anything below here```. The Weather Source and OpenWeather API key should be set or changed through the [Web UI](../README.md#web-ui) not in the ***CDCdefines.h*** file.  
-<br>**IMPORTANT:** **DO NOT** modify the URLs for API or Icon calls.
+7. Do not modify any of the ```#define``` values below the line  ```DO NOT change anything below here```. The Weather Source and OpenWeather API key should be set or changed through the [Web UI](../README.md#web-ui) not in the ***CDCdefines.h*** file.
 
-### Build and Configure a New Device
+>[!IMPORTANT]
+>**DO NOT** modify the URLs for Weather API or Icon calls.
 
-#### Build and Install the Firmware
+### Build and Install the Firmware
 
 1. After [configuring the Arduino IDE](#setting-up-your-build-environment), build and upload the firmware to your ESP32.  
    Make sure to have selected the *Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)* partition scheme.  
@@ -166,110 +216,74 @@ As of V2.2.0 changes to the ***CDCdefines.h*** file are **not** required since a
    * **LittleFS file system formatting MUST be used for the data upload.**
    * These files are needed for the Web UI as well as configuration of the CheapoDC.
   
-#### First Time Device Configuration
+### First Time Device Configuration
 
 If you have not modified the default CDCWiFi.json then the CheapoDC will enter AP (Access Point) mode when booted the first time.
 
-* Connect to the access point, SSID: cheapodc and Password: cheapodc.
-* Browse to the CheapoDC Web UI at [http://cheapodc.local](http://cheapodc.local) to configure your device. When prompted login using the default userid and password: admin, admin. You should be on the [Dashboard](../README.md#cheapodc-dashboard) page.
-* Go to the [Device Management](../README.md#cheapodc-device-management) page by clicking on the button at the bottom of the page.
+* Connect to the access point, SSID: CheapoDC and Password: CheapoDC.
+* Browse to the CheapoDC Web UI at [http://CheapoDC.local](http://CheapoDC.local) to configure your device. When prompted login using the default userid and password: admin, admin. You should be on the [Dashboard](../README.md#CheapoDC-dashboard) page.
+* Go to the [Device Management](../README.md#CheapoDC-device-management) page by clicking on the button at the bottom of the page.
 * Scroll down to [WiFi Configuration](../README.md#wifi-configuration) and configure your WiFi SSID and Password. You'll need to [Reboot](../README.md#reboot-device) the CheapoDC for the WiFi changes to take effect.
 * After rebooting. The CheapoDC should be connected to your WiFi network. Refresh your browser and stay on the Device Management page.
 * Configure the [Controller Outputs](../README.md#controller-output-configuration) if needed. Output 0 and 1 are always dew controller outputs and by default mapped to GPIO pins 0 and 1. Outputs 2 to 5 may be configured as Controller, PWM or Boolean. They are Disabled by default. Outputs **must** be mapped to a GPIO pin first before an [Output Mode](../README.md#output-modes) may be set.  
   For the ESP32-C3 SuperMini GPIO pins 0, 1, 3, 4, 5 and 7 have been validated.
 * [Change your password](../README.md#change-password).
 * Set up the Humidity Sensor if you have [added one to your device](../README.md#humidity-sensor-configuration). A [Reboot](../README.md#reboot-device) of the device will be required for SDA and SCL pin changes to take effect.  
-  For the ESP32-C3 SuperMini GPIO pins 9 (SCL) anf 10 (SDA) have been validated.
+  For the ESP32-C3 SuperMini GPIO pins 9 (SCL) and 10 (SDA) have been validated.
 * [Change the Status LED](../README.md#status-led-configuration) GPIO pin and High Value setting if needed. GPIO pin 8 is the default while setting it to -1 will disable the LED.
-* Go to the [Controller Configuration](../README.md#cheapodc-controller-configuration) page to set up the parameters for the dew controller, weather query and your location. Dew controller parameters are explained in the [Dew Control Algorithm](../README.md#how-the-dew-control-algorithm-works) section.
+* Go to the [Controller Configuration](../README.md#CheapoDC-controller-configuration) page to set up the parameters for the dew controller, weather query and your location. Dew controller parameters are explained in the [Dew Control Algorithm](../README.md#how-the-dew-control-algorithm-works) section.
 
 Your CheapoDC should now be ready to use.
 
-### Upgrading from a previous release
-
-There are four methods described below for upgrading CheapoDC firmware. Two methods require a computer and USB connection to the device while the other two leverage Over The Air (OTA) update methods.
-
-**Note:** Upgrade method [2. Upgrade using USB Connected Device and WebFlash](#2-upgrade-using-usb-connected-device-and-webflash) must be used if your device does not use the *Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)* partition scheme.
-
-#### 1. Upgrade using USB Connected Device and Arduino IDE
-
-1. Preserve your current CheapoDC configuration and WiFi settings by first downloading the CDCConfig.json and CDCWiFi.json files
-from your CheapoDC. This can be done using the Web UI from the [File Management](../README.md#cheapodc-file-management) page.
-Place both files in the sketch data folder: ***CheapoDC/data***.
-2. Build and upload the new firmware to your device.
-   * If upgrading from a pre-V2.1.0 release, make sure to set *Erase All Flash Before Sketch Upload:* ***"Enabled"***  
-   **NOTE:** Make sure to reset this to **"Disabled"** once you are done with the upgrade or the LittleFS partition will be erased with each
-   firmware upload and you will need to upload your sketch data every time.
-   * Make sure to have selected the *Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)* partition scheme.
-3. Upload the files in the CheapoDC/data folder using the Sketch data uploading tool. Make sure to use an upload tool for the LittleFS filesystem.
-4. Your upgrade should now be complete.
-
-#### 2. Upgrade using USB Connected Device and WebFlash
-
-1. WebFlash will erase all flash memory on your CheapoDC. You must backup your current CheapoDC configuration and WiFi settings by first downloading the **CDCConfig.json** and **CDCWiFi.json** files
-from your CheapoDC. This can be done using the Web UI from the [File Management](../README.md#cheapodc-file-management) page.
-2. Use [WebFlash](https://hcomet.github.io/CheapoDC/CheapoDCFlash.html) to install the latest CheapoDC firmware onto your device.
-3. Once the device has rebooted, it will be in access point mode. Use your computer to connect to the access point, SSID: cheapodc and Password: cheapodc.
-4. Browse to the CheapoDC Web UI at http://cheapodc.local and login using the default userid and password: admin, admin.
-5. Upload the previously backed up **CDCConfig.json** and **CDCWifi.json** files using the File Management page.
-5. Goto to the Device Management page and reboot the device to complete the upgrade.
-
-#### 3. Web OTA Update
-
-Introduced in the V2.2.0 release, the aim of [Web OTA Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html) is to make upgrades simple and easy. 
-When a new release is available it will be indicated in the **Web OTA Update**
-section on the **Device Management** of the WebUI.
-
->[!IMPORTANT]
-> Due to a change to the issuing CA for GitHub Pages HTTPS certificates, Web OTA Update from V2.3.0 or earlier no longer works. One of the other upgrade methods must be used to update to V2.3.1 or newer. V2.3.1 fixes the issue and Web OTA Update should work properly from that version onwards.
-
-#### 4. Manual OTA Update
-
-Manual OTA Update allows you to do an OTA update using your own copy of the CheapoDC firmware binary image. Use the following steps:
-
-1. Download the latest firmware release source code from <https://github.com/hcomet/CheapoDC/releases> and extract it to your local file system.
-2. Get or generate the firmware binary image file by either:
-
-   1. Downloading the latest CheapoDC binary image file from [https://hcomet.github.io/CheapoDC/firmware/CheapoDC.ESP32-C3.bin](https://hcomet.github.io/CheapoDC/firmware/CheapoDC.ESP32-C3.bin).
-   2. Or, generating the firmware binary image using the Arduino IDE and selecting `Sketch->Export Compiled Binary`. This will create a ***CheapoDC.ino.bin*** file under a ***build*** folder created in your sketch folder.  
-   **Note:** Follow the instructions in [Build and Install the Firmware](#build-and-install-the-firmware) to set up the Arduino IDE for CheapoDC builds.
-
-3. Use the **Manual OTA Update** `Choose File` in the Web UI to select the ***.bin*** file from step 2. Then click `Update` to flash the CheapoDC to the new version.
-4. After the reboot, go to the [File Management](../README.md#cheapodc-file-management) page to upload the new release data files. Use `Choose Files` to browse to the ***CheapoDC/CheapoDC/data*** folder in the downloaded release from step 1. Then select all files **EXCEPT** the CDCWiFi.json file. Then click `Upload`.
-5. Your upgrade should now be complete.
-
-### Configuration Files
+## Configuration Files
 
 All of the configuration information for the CheapoDC is stored in two files save to the data partition on the device.
 
-#### CDCWiFi.json
+### CDCWiFi.json
 
-This file provides a list of WiFi access points that will be tried by the CheapoDC to establish a network connection. The Hostname and WiFi access point information may be modified using the [Web UI](../README.md#wifi-configuration). However, This file may be edited and uploaded using the [File Management](../README.md#cheapodc-file-management) page.
+This file provides a list of WiFi access points that will be tried by the CheapoDC to establish a network connection. The Hostname and WiFi access point information may be modified using the [Web UI](../README.md#wifi-configuration). This file may also be edited and uploaded using the [File Management](../README.md#CheapoDC-file-management) page.
 
 The file content is json formatted using "name":"value" pairs.
 
-`{"hostname":"cheapodc","connectAttempts":"10","tryAPs":"1","wifi":[{"ssid":"FakeSSID1","password":"Password1"},{"ssid":"FakeSSID2","password":"Password2"}]}`
+`{"hostname":"CheapoDC","connectAttempts":"10","tryAPs":"1","wifi":[{"ssid":"FakeSSID1","password":"Password1"},{"ssid":"FakeSSID2","password":"Password2"}]}`
 
 The example shows settings for two access points in the "wifi" section. This can be 1 or several access points. CheapoDC will step through the list sequentially until a successful WiFi connection is established in Station Mode.
 
 1. Replace "FakeSSID1" and "Password1" for the first AP to try with your first SSID and password.
 ```{"ssid":"FakeSSID1","password":"Password1"}```
-2. To set up a second AP (or more) then update "FakeSSID2" and "Password2" for the second AP (or add more entries separated by commas for more APs). If you only want one AP then delete the entry including the preceding comma.  
+2. To set up a second AP (or more) then update "FakeSSID2" and "Password2" for the second AP (or add more entries separated by commas for more APs). If you only want one AP, then delete the entry including the preceding comma.  
 ```{"ssid":"FakeSSID2","password":"Password2"}```
-3. You can also change the "hostname" from the default of ***cheapodc***.  
-```"hostname":"cheapodc"```  
+3. You can also change the "hostname" from the default of ***CheapoDC***.  
+```"hostname":"CheapoDC"```  
 **Note:** Changing the hostname will also change the SSID for the device when in Access Point mode.
 4. Changing "connectAttempts" will change then number of times the CheapoDC will attempt to connect to an access point before moving to the next access point in the list.  
 ```"connectAttempts":"10"```
 5. Changing "tryAPs" will change the number of times the CheapoDC will loop through the list of access points before switching to Access Point (AP) mode.  
 ```"tryAPs":"1"```
 
-If CheapoDC fails to connect to an access point in Station Mode then it will switch to Access Point (AP) mode. The AP SSID will be the same as the hostname with a default of *cheapodc*. The AP password is always *cheapodc* and can only be changed in the  [***CDCdefines.h***](#configure-firmware-in-the-cdcdefinesh-file) file.
+If CheapoDC fails to connect to an access point in Station Mode, then it will switch to Access Point (AP) mode. The AP SSID will be the same as the hostname with a default of *CheapoDC*. The AP password is always *CheapoDC* and can only be changed in the  [***CDCdefines.h***](#configure-firmware-in-the-cdcdefinesh-file) file.
 
-If no ***CDCWiFi.json*** file is found then the values for WiFi configuration will be taken from the [***CDCdefines.h***](#configure-firmware-in-the-cdcdefinesh-file) file.
+If no ***CDCWiFi.json*** file is found, then the values for WiFi configuration will be taken from the [***CDCdefines.h***](#configure-firmware-in-the-cdcdefinesh-file) file.
 
-#### CDCConfig.json
+### CDCConfig.json
 
-This file is used to save the dew controller configuration between power cycles. If the file is not present then the values defined in the ***CDCdefines.h*** file (the firmware defaults) will be used. The CheapoDC checks for changes to the controller's configuration every 10 seconds and if a change is detected then the full ***CDCdefines.h*** file will be written to the LittleFS file system on the controller.
+This file is used to save the dew controller configuration between power cycles. If the file is not present, then the values defined in the ***CDCdefines.h*** file (the firmware defaults) will be used. The CheapoDC checks for changes to the controller's configuration every 10 seconds and if a change is detected then the full ***CDCdefines.h*** file will be written to the LittleFS file system on the controller.
 
-Controller configuration may be modified via the [Web UI](../README.md/#web-ui) or the [CheapoDC API](../README.md/#cheapodc-api). The [CheapoDC commands](../README.md/#cheapodc-commands) which support a ***Setter*** function also represent the values stored in the ***CDCConfig.json*** file.
+Controller configuration may be modified via the [Web UI](../README.md/#web-ui) or the [CheapoDC API](../README.md/#CheapoDC-api). The [CheapoDC commands](../README.md/#CheapoDC-commands) which support a ***Setter*** function also represent the values stored in the ***CDCConfig.json*** file.
+
+## Web OTA Root CA Issue
+
+CheapoDC uses esp32FOTA to detect the availability of a CheapoDC firmware update. The updates are hosted at [https://hcomet.github.io/](https://hcomet.github.io/) on GitHub Pages. The version of esp32FOTA used in CheapoDC V2.2.0 and V2.3.0 required that the root CA for the hosting site be provided to verify the HTTPS link to the site. When the root CA for GitHub Pages was changed after the CheapoDC V2,3,0 release, updates could no longer be verified. Automatic Web OTA Update for V2.2.0 and V2.3.0 stopped working.
+
+CheapoDC V2.3.1 uses the latest  esp32FOTA library which allows for a root CA bundle to be passed and processed to verify the Web OTA Update link. The CA bundle used in V2.3.1 is based on the May 2026 Mozilla trusted CA list. This should prevent future issues with a change in trusted CA at GitHub Pages.
+
+### How to Re-enable Web OTA Update
+
+CheapoDC V2.2.0 and V2.3.0 both support the ability to change the trusted root CA used for Web OTA Update. This is done by uploading a new CA certificate to CheapoDC as a PEM encoded file. If you are currently using V2.2.0 or V2.3.0 follow these steps to perform a firmware update:
+
+1. Get the new root CA by downloading [***root_ca.pem***](https://hcomet.github.io/CheapoDC/root_ca.pem) to your computer.
+2. Make sure your CheapoDC is powered up and then browse to the WebUI and logon.
+3. Go to the **File Management** page and upload the ***root_ca.pem*** file from step 1.
+4. Go to the **Device Management** page and reboot your CheapoDC.
+5. Once rebooted, a new firmware release (2.3.1 or newer) should be shown as available under Web OTA Update on the **Device Management** page.
+6. Enter your CheapoDC password and click `Update` to complete the update.

--- a/CheapoDC/README.md
+++ b/CheapoDC/README.md
@@ -1,18 +1,17 @@
-# WebFlash as an Option
+# Installing CheapoDC
 
-If you are using an [ESP32-C3 SuperMini](https://michiel.vanderwulp.be/domotica/Modules/ESP32-C3-SuperMini/) or any other ESP32-C3 module then the easiest way to load the CheapoDC firmware onto your device is to use [WebFlash](https://hcomet.github.io/CheapoDC/CheapoDCFlash.html). All other configuration can then be done through the [Web UI](../README.md#web-ui). WebFlash is primarily for new installs but you can also use it for a firmware upgrade. WebFlash will erase all flash memory on your ESP32-C3, so if upgrading, **remember to backup your configuration files (CDCConfig.json & CDCWifi.json)**.
+## WebFlash, the Easy Option
 
-Go to the [WebFlash page](https://hcomet.github.io/CheapoDC/CheapoDCFlash.html) to install CheapoDC on your ESP32-C3. Then follow the instructions bellow in the [First Time Device Configuration](#first-time-device-configuration) section.
+If you are using an [ESP32-C3 SuperMini](https://michiel.vanderwulp.be/domotica/Modules/ESP32-C3-SuperMini/) or any other ESP32-C3 module then the easiest way to load the CheapoDC firmware onto your device is to use [WebFlash](https://hcomet.github.io/CheapoDC/CheapoDCFlash.html). All other configuration can then be done through the [Web UI](../README.md#web-ui). WebFlash is primarily for new installs but you can also use it to upgrade your CheapoDC to the latest firmware. Details in the [Upgrading from a Previous Release](#2-upgrade-using-usb-connected-device-and-webflash) section.
+
+You need to connect your ESP32-C3 to your computer via USB to use WebFlash. Go to the [WebFlash page](https://hcomet.github.io/CheapoDC/CheapoDCFlash.html) to install CheapoDC on your ESP32-C3. Then follow the instructions bellow in the [First Time Device Configuration](#first-time-device-configuration) section.
+
+
 
 If you prefer to build the firmware yourself using the Arduino IDE please continue on to [Building and Installing CheapoDC](#building-and-installing-cheapodc)
 
-Note that as of CheapoDC V2.2.0, the Web UI supports an semi-automatic web-based upgrade that preserves your configuration files. Web OTA Update while upgrading the firmware and data partitions. See the documentation on [Web OTA Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html) for details.
-
-# Building and installing CheapoDC
-
-## If you are Upgrading from a Previous Release
-
-This note is to highlight the change in recommended partition scheme implemented for release V2.1.0. If you are upgrading from a release prior to V2.1.0 then you will need to switch partition schemes as part of the upgrade. Please read the [Partition Scheme](#partition-scheme) section for the reasons for the change. Unfortunately, upgrading from CheapDC 2.3.0 to 2.3.1 must be done using the Manual OTA Update in the Web UI, Device Management page.
+>[NOTE!]
+>CheapoDC V2.2.0 added Web UI support for a semi-automatic web-based upgrade that preserves your configuration files. See the documentation on [Web OTA Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html) for details.
 
 ## Changes in CheapoDC V2
 
@@ -60,17 +59,27 @@ CheapoDC configuration files.
 11. As of V2.3.0, when in Access Point Mode, CheapoDC will use the hostname for the SSID.
 12. See the CheapoDC [release notes](https://github.com/hcomet/CheapoDC/releases) for additional details.
 
-## Setting Up Your Build Environment
+## Building and Installing CheapoDC
+
+### Partition Scheme
+
+The ESP32 Partition Scheme is a term used by the Arduino IDE to select a partition table that defines the flash memory organization and the different kinds of data that will be stored in each partition. The ESP32-C3, which this project uses, generally has 4MB of flash memory with the default partition scheme of *Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)*.
+
+The *Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)* partition scheme provides two application partitions of 1.2MB to support OTA updates plus a 1.5MB SPIFFS partition used for LittleFS file storage. The latest version of CheapoDC using the latest Arduino library versions requires about 1.6MB of application space.
+
+To allow for OTA updates, LittleFS storage and some expansion room for CheapoDC firmware the *Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)* partition scheme is used. This scheme provides too little space for the CheapoDC HTML, CSS and JS files without compression. The repository [**data source**](../data%20source/) folder contains he original source for these files. The repository [**CheapoDC/data**](../CheapoDC/data/) folder contains minified or compressed versions for installation in the LittleFS formatted data partition.
+
+### Setting Up Your Build Environment
 
 1. Install the Arduino IDE.  
-  <u>**NOTE:**</u> Version 2.3.8 of the Arduino IDE is required. As of CheapoDC V2.3.1 verification of
+  **NOTE:** Version 2.3.8 of the Arduino IDE is required. As of CheapoDC V2.3.1 verification of
   builds will only be done on IDE version 2.3.8 or newer.
 2. Add support for ESP32 modules using the Boards Manager in the Arduino IDE.  
-  <u>**IMPORTANT:**</u>
+  **IMPORTANT:**
     * Install the boards plugin for ESP32 from Espressif Systems version 3.3.8 (Arduino core for the ESP32). CheapoDC V2.3.1 verification has been done with version 3.3.8.
     * CheapoDC is intended for use on ESP32 devices. The current version has been verified on an [ESP32-C3 SuperMini](https://michiel.vanderwulp.be/domotica/Modules/ESP32-C3-SuperMini/) board..
 3. Install the ESP32 Sketch data uploader with support for LittleFS. The CheapoDC uses the LittleFS file system for configuration files and web pages uploaded from the ***CheapoDC/data*** folder. If the data is uploaded using any other file system format, such as SPIFFS, the CheapoDC firmware will not run properly.  
-<u>**NOTE:**</u> The following link provides information on how to install a data uploader plugin with LittleFS support:
+**NOTE:** The following link provides information on how to install a data uploader plugin with LittleFS support:
     * Arduino IDE 2.3.2+: [https://randomnerdtutorials.com/arduino-ide-2-install-esp32-littlefs/](https://randomnerdtutorials.com/arduino-ide-2-install-esp32-littlefs/)
 
 4. Install the following libraries if not already installed:
@@ -89,23 +98,21 @@ CheapoDC configuration files.
    * [ESP32CertBundle](https://github.com/tanakamasayuki/ESP32CertBundle)  
      Version: 20260514.0.0
 
-   <u>**NOTES:**</u>
-   * CheapoDC V2.1.0 has migrated from the [dvarrel](https://github.com/dvarrel) versions of EspAsyncWebServer and AsyncTCP to the [ESP32Async Organization](https://github.com/ESP32Async) versions. ESP32Async Organization looks to be very proactive in maintaining the libraries and also contains members of the Arduino core for ESP32 team helping to keep it in sync. Currently the Arduino Library Manager shows Me-No-Dev as the owner but will likely change to ESP32Async.
-   * If you have other versions of the ESPSyncWebServer or AsyncTCP not from the links above they will need to be uninstalled to prevent issues with the build.
+   **NOTES:**
+   * Make sure that the only versions of **ESP Async WebServer** and **Async TCP** are the ones by ESP32Async. If you have other versions of the ESPSyncWebServer or AsyncTCP not from the links above they will need to be uninstalled to prevent issues with the build.
    * In general, if newer versions of a library are available then only use new subversions not new major versions. CheapoDC v2.3.1 was verified using the versions of libraries listed above.
 
 5. Download the latest firmware release source code from <https://github.com/hcomet/CheapoDC/releases>  
-  <u>**NOTE:**</u> After extracting the release to your file system open the CheapoDC.ino file in the Arduino IDE. This will open the full set of source files in the IDE. Now configure the firmware before building it.
+  **NOTE:** After extracting the release to your file system open the CheapoDC.ino file in the Arduino IDE. This will open the full set of source files in the IDE. Now configure the firmware before building it.
 
-### IDE Tips
+>[!TIP]
+>* Many ESP32-C3 board configurations (Dev Module, mini, super mini, micro etc..) have *USB CDC On BOOT:* ***"Disabled"***. This needs to be ***"ENABLED"*** or the Serial Monitor will not work.
+>* CheapoDC uses *115200 baud* for the Serial Monitor Connection. Leave the default baud rate for the upload.
+>* Its good practice to set *Erase All Flash Before Sketch Upload:* ***"Enabled"*** the first time you upload a new project to an ESP32. After that, make sure its set to ***"Disabled"*** to preserve the LittleFS partition content between uploads.
 
-* Many ESP32-C3 board (Dev Module, mini, super mini, micro etc..) configurations have *USB CDC On BOOT:* ***"Disabled"***. This needs to be ***"ENABLED"*** or the Serial Monitor will not work.
-* CheapoDC uses *115200 baud* for the Serial Monitor Connection. Leave the default baud rate for the upload.
-* Its good practice to set *Erase All Flash Before Sketch Upload:* ***"Enabled"*** the first time you upload a new project to an ESP32. After that, make sure its set to ***"Disabled"*** to preserve the LittleFS partition content between uploads.
+### Configure Firmware in the CDCdefines.h file
 
-## Configure Firmware in the CDCdefines.h file
-
-As of V2.2.0 changes to the ***CDCdefines.h*** file are <u>**not**</u> required since all key items can now be modified at runtime, via the [WebUI](../README.md#web-ui), and are saved to the [CDCConfig.json](#cdcconfigjson). If you do wish to to configure/customize the firmware before building the following items may be modified in the ***CDCdefines.h*** file:
+As of V2.2.0 changes to the ***CDCdefines.h*** file are **not** required since all key items can now be modified at runtime, via the [WebUI](../README.md#web-ui), and are saved to the [CDCConfig.json](#cdcconfigjson). If you do wish to to configure/customize the firmware before building the following items may be modified in the ***CDCdefines.h*** file:
 
 1. Set the default ESP32 GPIO pins to be used for Controller Outputs 0 & 1. ***DEFAULT: 0 & 1***.  
     ```#define CDC_DEFAULT_CONTROLLER_PIN0 0```  
@@ -113,15 +120,15 @@ As of V2.2.0 changes to the ***CDCdefines.h*** file are <u>**not**</u> required 
     *May be changed through the Web UI or API*
 2. Set the PWM channel to use for Controller Outputs. ***DEFAULT: 0***.  
     ```#define CDC_CONTROLLER_PWM_CHANNEL 0```  
-  <u>**NOTE:**</u> Changing this value may have a negative impact on CheapoDC operation. PWM channels 1 through 4 are reserved for the use of the additional Controller Outputs 2 through 5.
+  **NOTE:** Changing this value may have a negative impact on CheapoDC operation. PWM channels 1 through 4 are reserved for the use of the additional Controller Outputs 2 through 5.
 3. Set the pin for the status LED on you ESP32. ***DEFAULT: 8***.  
     ```#define CDC_DEFAULT_STATUS_LED_PIN 8```  
     *May be changed through the Web UI or API*  
-    <u>**NOTE:**</u> Some ESP32-C3 modules have the Status LED wired so that setting the status pin high is off or reversed. Uncomment this line to reverse the High/Low setting for the status LED pin.  
+    **NOTE:** Some ESP32-C3 modules have the Status LED wired so that setting the status pin high is off or reversed. Uncomment this line to reverse the High/Low setting for the status LED pin.  
     ```//#define CDC_REVERSE_HIGH_LOW```  
     *May be changed through the Web UI or API*
 4. Set up the WiFi configuration.  The CheapoDC may operate in either Access Point (AP) mode or Station (ST) mode. The CheapoDC defaults to AP mode when it cannot connect to an access point.  The AP mode SSID will be set to be the same as the hostname which defaults to ***cheapodc***.  
-<u>**NOTE:**</u> Changing the WiFi configuration is **NOT** recommended. ST Mode settings can be changed in the Web UI while AP Mode settings will be overwritten if Web OTA Update is used.
+**NOTE:** Changing the WiFi configuration is **NOT** recommended. ST Mode settings can be changed in the Web UI while AP Mode settings will be overwritten if Web OTA Update is used.
     * AP Mode settings must be configured in the ***CDCdefines.h*** file:  
       * Change AP mode password. ***DEFAULT: cheapodc***.  
         ```#define CDC_DEFAULT_WIFI_AP_PASSWORD "cheapodc"```  
@@ -136,22 +143,22 @@ As of V2.2.0 changes to the ***CDCdefines.h*** file are <u>**not**</u> required 
         Uncomment to enable. If enabled the default value sets TX power to 8.5dbm. Any of the `wifi_power_t` values found [here](https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFi/src/WiFiGeneric.h#L51-L67) may be used. Extensive testing with WiFi TX Power settings has **NOT** been done.
 
 5. The hostname for the CheapoDC may also be changed. Its recommended that this be done using the [Web UI](../README.md#wifi-configuration). This is really only needed if you have multiple CheapoDC controllers on the same network.  To change the hostname in the ***CDCdefines.h*** file:  
-<br><u>**NOTE:**</u> When in access point (AP) mode the SSID for the AP will be the same as the hostname.
+<br>**NOTE:** When in access point (AP) mode the SSID for the AP will be the same as the hostname.
     * Change the host name. ***DEFAULT: cheapodc***.  
       ```#define CDC_DEFAULT_HOSTNAME "cheapodc"```  
       *Recommended to be modified only through the Web UI or API*
 6. As of firmware V2.2.0, CheapoDC supports a [Web Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html) capability. This is enabled by default but can be disabled by commenting out the following line:  
     ```#define CDC_ENABLE_HTTP_OTA```
 7. Do not modify any of the ```#define``` values below the line  ```DO NOT change anything below here```. The Weather Source and OpenWeather API key should be set or changed through the [Web UI](../README.md#web-ui) not in the ***CDCdefines.h*** file.  
-<br><u>**IMPORTANT:**</u> **DO NOT** modify the URLs for API or Icon calls.
+<br>**IMPORTANT:** **DO NOT** modify the URLs for API or Icon calls.
 
-## Build and Configure a New Device
+### Build and Configure a New Device
 
-### Build and Install the Firmware
+#### Build and Install the Firmware
 
 1. After [configuring the Arduino IDE](#setting-up-your-build-environment), build and upload the firmware to your ESP32.  
    Make sure to have selected the *Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)* partition scheme.  
-   <u>**NOTE:**</u> If the *Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)* partition scheme is not listed as one of the partition schemes available for your selected ESP32-C3 board type you will need to select a different board type. Often the AliExpress type boards only list a minimal set of partition schemes. If you do not see the *Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)* in the list of available partition schemes for your board the best recommendation is to select a Dev Module board in the Arduino IDE. For the ESP32-C3 that would be the *ESP32C3 Dev Module*.
+   **NOTE:** If the *Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)* partition scheme is not listed as one of the partition schemes available for your selected ESP32-C3 board type you will need to select a different board type. Often the AliExpress type boards only list a minimal set of partition schemes. If you do not see the *Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)* in the list of available partition schemes for your board the best recommendation is to select a Dev Module board in the Arduino IDE. For the ESP32-C3 that would be the *ESP32C3 Dev Module*.
 
 2. Optionally, modify the CDCWiFi.json file ([see below](#cdcwifijson)) in the sketch ***CheapoDC/data*** folder to configure WiFi for your network or modify the hostname.
 
@@ -159,7 +166,7 @@ As of V2.2.0 changes to the ***CDCdefines.h*** file are <u>**not**</u> required 
    * **LittleFS file system formatting MUST be used for the data upload.**
    * These files are needed for the Web UI as well as configuration of the CheapoDC.
   
-### First Time Device Configuration
+#### First Time Device Configuration
 
 If you have not modified the default CDCWiFi.json then the CheapoDC will enter AP (Access Point) mode when booted the first time.
 
@@ -178,58 +185,64 @@ If you have not modified the default CDCWiFi.json then the CheapoDC will enter A
 
 Your CheapoDC should now be ready to use.
 
-## Upgrading from a previous release
+### Upgrading from a previous release
 
-Note that V2.1.0 required a change in the [Partition Scheme](#partition-scheme) and upgrades from a pre-V2.1.0 release must be done using a USB connection to the device.
+There are four methods described below for upgrading CheapoDC firmware. Two methods require a computer and USB connection to the device while the other two leverage Over The Air (OTA) update methods.
 
-New versions of ESPAsyncWebServer and AsyncTCP libraries are also required for Arduino core of ESP32 version 3.1.x. Please read the [Setting Up Your Build Environment](#setting-up-your-build-environment) section to make sure you have the correct libraries installed in the Arduino IDE. Be sure to have only one version of the AsyncTCP library installed.
+**Note:** Upgrade method [2. Upgrade using USB Connected Device and WebFlash](#2-upgrade-using-usb-connected-device-and-webflash) must be used if your device does not use the *Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)* partition scheme.
 
-### Upgrade using USB Connected Device
+#### 1. Upgrade using USB Connected Device and Arduino IDE
 
 1. Preserve your current CheapoDC configuration and WiFi settings by first downloading the CDCConfig.json and CDCWiFi.json files
 from your CheapoDC. This can be done using the Web UI from the [File Management](../README.md#cheapodc-file-management) page.
 Place both files in the sketch data folder: ***CheapoDC/data***.
 2. Build and upload the new firmware to your device.
    * If upgrading from a pre-V2.1.0 release, make sure to set *Erase All Flash Before Sketch Upload:* ***"Enabled"***  
-   <u>**NOTE:**</u> Make sure to reset this to **"Disabled"** once you are done with the upgrade or the LittleFS partition will be erased with each
+   **NOTE:** Make sure to reset this to **"Disabled"** once you are done with the upgrade or the LittleFS partition will be erased with each
    firmware upload and you will need to upload your sketch data every time.
    * Make sure to have selected the *Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)* partition scheme.
 3. Upload the files in the CheapoDC/data folder using the Sketch data uploading tool. Make sure to use an upload tool for the LittleFS filesystem.
 4. Your upgrade should now be complete.
 
-### OTA Upgrade using the Web UI Firmware Update
+#### 2. Upgrade using USB Connected Device and WebFlash
 
-If upgrading from a release prior to V2.1.0, an OTA firmware upgrade cannot be used. Go back to the [USB connected upgrade](#upgrade-using-usb-connected-device).
+1. WebFlash will erase all flash memory on your CheapoDC. You must backup your current CheapoDC configuration and WiFi settings by first downloading the **CDCConfig.json** and **CDCWiFi.json** files
+from your CheapoDC. This can be done using the Web UI from the [File Management](../README.md#cheapodc-file-management) page.
+2. Use [WebFlash](https://hcomet.github.io/CheapoDC/CheapoDCFlash.html) to install the latest CheapoDC firmware onto your device.
+3. Once the device has rebooted, it will be in access point mode. Use your computer to connect to the access point, SSID: cheapodc and Password: cheapodc.
+4. Browse to the CheapoDC Web UI at http://cheapodc.local and login using the default userid and password: admin, admin.
+5. Upload the previously backed up **CDCConfig.json** and **CDCWifi.json** files using the File Management page.
+5. Goto to the Device Management page and reboot the device to complete the upgrade.
 
-If upgrading from V2.1.0 or newer then use **Manual Update** on the Web UI [Device Management](../README.md#cheapodc-device-management) page.
+#### 3. Web OTA Update
 
-#### Web OTA Update
+Introduced in the V2.2.0 release, the aim of [Web OTA Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html) is to make upgrades simple and easy. 
+When a new release is available it will be indicated in the **Web OTA Update**
+section on the **Device Management** of the WebUI.
 
-Introduced in the V2.2.0 release, [Web OTA Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html) which makes upgrades simple and easy.  
 >[!IMPORTANT]
-> Due to a change to the issuing CA for GitHub Pages HTTPS certificate upgrading from V2.3.0 or earlier must be done using Manual OTA Update. V2.3.1 fixes the issue.
+> Due to a change to the issuing CA for GitHub Pages HTTPS certificates, Web OTA Update from V2.3.0 or earlier no longer works. One of the other upgrade methods must be used to update to V2.3.1 or newer. V2.3.1 fixes the issue and Web OTA Update should work properly from that version onwards.
 
-#### Manual OTA Update
+#### 4. Manual OTA Update
 
 Manual OTA Update allows you to do an OTA update using your own copy of the CheapoDC firmware binary image. Use the following steps:
 
 1. Download the latest firmware release source code from <https://github.com/hcomet/CheapoDC/releases> and extract it to your local file system.
 2. Get or generate the firmware binary image file by either:
 
-   * Downloading the latest CheapoDC binary image file from [https://hcomet.github.io/CheapoDC/firmware/CheapoDC.ESP32-C3.bin](https://hcomet.github.io/CheapoDC/firmware/CheapoDC.ESP32-C3.bin).
-   * Generating the firmware binary image using the Arduino IDE and selecting `Sketch->Export Compiled Binary`. This will create a ***CheapoDC.ino.bin*** file under a ***build*** folder created in your sketch folder.  
-     > [!NOTE]
-     > Follow the instructions in [Build and Install the Firmware](#build-and-install-the-firmware) to set up the Arduino IDE for CheapoDC builds.
+   1. Downloading the latest CheapoDC binary image file from [https://hcomet.github.io/CheapoDC/firmware/CheapoDC.ESP32-C3.bin](https://hcomet.github.io/CheapoDC/firmware/CheapoDC.ESP32-C3.bin).
+   2. Or, generating the firmware binary image using the Arduino IDE and selecting `Sketch->Export Compiled Binary`. This will create a ***CheapoDC.ino.bin*** file under a ***build*** folder created in your sketch folder.  
+   **Note:** Follow the instructions in [Build and Install the Firmware](#build-and-install-the-firmware) to set up the Arduino IDE for CheapoDC builds.
 
 3. Use the **Manual OTA Update** `Choose File` in the Web UI to select the ***.bin*** file from step 2. Then click `Update` to flash the CheapoDC to the new version.
 4. After the reboot, go to the [File Management](../README.md#cheapodc-file-management) page to upload the new release data files. Use `Choose Files` to browse to the ***CheapoDC/CheapoDC/data*** folder in the downloaded release from step 1. Then select all files **EXCEPT** the CDCWiFi.json file. Then click `Upload`.
 5. Your upgrade should now be complete.
 
-## Configuration Files
+### Configuration Files
 
 All of the configuration information for the CheapoDC is stored in two files save to the data partition on the device.
 
-### CDCWiFi.json
+#### CDCWiFi.json
 
 This file provides a list of WiFi access points that will be tried by the CheapoDC to establish a network connection. The Hostname and WiFi access point information may be modified using the [Web UI](../README.md#wifi-configuration). However, This file may be edited and uploaded using the [File Management](../README.md#cheapodc-file-management) page.
 
@@ -255,29 +268,8 @@ If CheapoDC fails to connect to an access point in Station Mode then it will swi
 
 If no ***CDCWiFi.json*** file is found then the values for WiFi configuration will be taken from the [***CDCdefines.h***](#configure-firmware-in-the-cdcdefinesh-file) file.
 
-### CDCConfig.json
+#### CDCConfig.json
 
 This file is used to save the dew controller configuration between power cycles. If the file is not present then the values defined in the ***CDCdefines.h*** file (the firmware defaults) will be used. The CheapoDC checks for changes to the controller's configuration every 10 seconds and if a change is detected then the full ***CDCdefines.h*** file will be written to the LittleFS file system on the controller.
 
 Controller configuration may be modified via the [Web UI](../README.md/#web-ui) or the [CheapoDC API](../README.md/#cheapodc-api). The [CheapoDC commands](../README.md/#cheapodc-commands) which support a ***Setter*** function also represent the values stored in the ***CDCConfig.json*** file.
-
-## Partition Scheme
-
-The ESP32 Partition Scheme is a term used by the Arduino IDE to select a partition table that defines the flash memory organization and the different kinds of data that will be stored in each partition. The ESP32-C3, which this project uses, generally has 4MB of flash memory with the default partition scheme of *Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)*.
-
-The *Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)* partition scheme provides two application partitions of 1.2MB to support OTA updates plus a 1.5MB SPIFFS partition used for LittleFS file storage. I selected this as the recommended partition scheme for the initial releases of CheapoDC because:
-
-1. Being a default scheme, it was available for all ESP32-C3 board types.
-2. The initial release of CheapoDC only needed 80% of the application partition space and I felt that future upgrades and fixes wouldn't need a lot more than that.
-3. The other predefined partition schemes didn't provide a good option for larger application size, OTA support and a partition large enough for the LittleFS data CheapoDC needed.
-
-It turns out that I was wrong about the second point. Although I have not added a lot of code to the initial version of CheapoDC the underlying libraries it relies on have changed and expanded in size. A combination of moving to the Arduino core for ESP32 3.1.x,
-Arduino 2.3.x, adopting the ESPAsync Organization version of ESPAsync Web Server plus other new library releases has put the CheapoDC V2.1.0 release at 98.6% of the application space. This is without Debug logging or WebSockets support enabled, which can no longer be enabled.
-
-The only solution is to move to a different partition scheme starting with CheapoDC release V2.1.0. As of V2.1.0 the recommended partition scheme is *Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)*. This scheme should hopefully provide plenty of application space going forward. The basic configuration of CheapoDC V2.1.0 takes 62% of the available space. In order to fit in the smaller SPIFFS partition the HTML, CSS and JS files used by CheapoDC have been run through a minimizer and additional compression applied to the PNG images.
-
-### Impact of the change in Partition Scheme
-
-If this is your first time building the CheapoDC then you are not affected. The [new device build instructions](#build-and-configure-a-new-device) still apply.
-
-If you are upgrading to V2.1.x from a release prior to V2.1.0 then you are affected. Read and follow the [upgrading from a previous release](#upgrading-from-a-previous-release) instructions.

--- a/CheapoDC/README.md
+++ b/CheapoDC/README.md
@@ -20,7 +20,7 @@ section on the **Device Management** page of the CheapoDC WebUI. Just enter your
 >[!IMPORTANT]
 > Due to a change to the issuing CA for GitHub Pages HTTPS certificates, Web OTA Update from V2.3.0 or earlier no longer works. V2.3.1 fixes the issue and Web OTA Update should work properly from that version onwards.
 >
-> Go to the section [***Web OTA Root CA Issue***](#web-ota-root-ca-issue) for details on how to get Web OTA Update to detect a new release and perform the firmware update from V2.2.0 or V2.3.0.
+> Go to the section [***Web OTA Update Root CA Issue***](#web-ota-update-root-ca-issue) for details on how to get Web OTA Update to detect a new release and perform the firmware update from V2.2.0 or V2.3.0.
 
 
 ### 2. Manual OTA Update
@@ -114,7 +114,7 @@ The *Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)* partition scheme provides
 
 To allow for OTA updates, LittleFS storage and some expansion room for CheapoDC firmware the *Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)* partition scheme is used. Although this scheme provides enough application space it provides too little SPIFFS (data partition) space for the CheapoDC HTML, CSS and JS files without compression. The repository [**data source**](../data%20source/) folder contains he original source for these files. The repository [**CheapoDC/data**](../CheapoDC/data/) folder contains minified or compressed versions for installation in the LittleFS formatted data partition.
 
-### Setting Up Your Build Environment\
+### Setting Up Your Build Environment
 
 1. Install the Arduino IDE.  
   **NOTE:** Version 2.3.10 of the Arduino IDE is required. As of CheapoDC V2.3.1 verification of
@@ -268,7 +268,7 @@ This file is used to save the device and dew controller configuration between po
 
 CheapoDC device and controller configuration may be modified via the [Web UI](../README.md/#web-ui) or the [CheapoDC API](../README.md/#cheapodc-api). The [CheapoDC commands](../README.md/#cheapodc-commands) which support a ***Setter*** function also represent the values stored in the ***CDCConfig.json*** file.
 
-## Web OTA Root CA Issue
+## Web OTA Update Root CA Issue
 
 CheapoDC uses esp32FOTA to detect the availability of a CheapoDC firmware update. The updates are hosted at [https://hcomet.github.io/](https://hcomet.github.io/) on GitHub Pages. The version of esp32FOTA used in CheapoDC V2.2.0 and V2.3.0 required that the root CA for the hosting site be provided to verify the HTTPS link to the site. When the root CA for GitHub Pages was changed after the CheapoDC V2,3,0 release, updates could no longer be verified. Automatic Web OTA Update for V2.2.0 and V2.3.0 stopped working.
 

--- a/CheapoDC/README.md
+++ b/CheapoDC/README.md
@@ -6,10 +6,7 @@ If you are using an [ESP32-C3 SuperMini](https://michiel.vanderwulp.be/domotica/
 
 You need to connect your ESP32-C3 to your computer via USB to use WebFlash. Go to the [WebFlash page](https://hcomet.github.io/CheapoDC/CheapoDCFlash.html) to install CheapoDC on your ESP32-C3. Then follow the instructions below in the [First Time Device Configuration](#first-time-device-configuration) section.
 
-If you prefer to build the firmware yourself using the Arduino IDE, please continue to [Building and Installing CheapoDC](#building-and-installing-CheapoDC)
-
->[NOTE!]
->CheapoDC V2.2.0 added Web UI support for a semi-automatic web-based upgrade that preserves your configuration files. See the documentation on [Web OTA Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html) for details.
+If you prefer to build the firmware yourself using the Arduino IDE, please continue to [Building and Installing CheapoDC](#building-and-installing-cheapodc)
 
 ## Upgrading from a Previous Release
 
@@ -17,11 +14,11 @@ There are four methods described below for upgrading CheapoDC firmware. Two leve
 
 ### 1. Web OTA Update
 
-Introduced in the V2.2.0 release, [Web OTA Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html) is the simple and easy way to upgrade your CHeapoDC firmware. When a new release is available it will be indicated in the **Web OTA Update**
+Introduced in the V2.2.0 release, [Web OTA Update](https://hcomet.github.io/CheapoDC/CheapoDCWebUpdate.html) is the simple and easy way to upgrade your CheapoDC firmware. When a new release is available it will be indicated in the **Web OTA Update**
 section on the **Device Management** page of the CheapoDC WebUI. Just enter your CheapoDC password, click `Update` and the new release will be installed while preserving your CheapoDC configuration files.
 
 >[!IMPORTANT]
-> Due to a change to the issuing CA for GitHub Pages HTTPS certificates, Web OTA Update from V2.3.0 or earlier no longer works. One of the other upgrade methods must be used to update to V2.3.1 or newer. V2.3.1 fixes the issue and Web OTA Update should work properly from that version onwards.
+> Due to a change to the issuing CA for GitHub Pages HTTPS certificates, Web OTA Update from V2.3.0 or earlier no longer works. V2.3.1 fixes the issue and Web OTA Update should work properly from that version onwards.
 >
 > Go to the section [***Web OTA Root CA Issue***](#web-ota-root-ca-issue) for details on how to get Web OTA Update to detect a new release and perform the firmware update from V2.2.0 or V2.3.0.
 
@@ -38,14 +35,14 @@ Manual OTA Update allows you to do an OTA update using your own copy of the Chea
    **Note:** Follow the instructions in [Build and Install the Firmware](#build-and-install-the-firmware) to set up the Arduino IDE for CheapoDC builds.
 
 3. Use the **Manual OTA Update** `Choose File` in the Web UI to select the ***.bin*** file from step 2. Then click `Update` to flash the CheapoDC to the new version.
-4. After the reboot, go to the [File Management](../README.md#CheapoDC-file-management) page to upload the new release data files. Use `Choose Files` to browse to the ***CheapoDC/CheapoDC/data*** folder in the downloaded release from step 1. Then select all files **EXCEPT** the CDCWiFi.json file. Then click `Upload`.
+4. After the reboot, go to the [File Management](../README.md#cheapodc-file-management) page to upload the new release data files. Use `Choose Files` to browse to the ***CheapoDC/CheapoDC/data*** folder in the downloaded release from step 1. Then select all files **EXCEPT** the CDCWiFi.json file. Then click `Upload`.
 5. Your upgrade should now be complete.
 
 
 ### 3. Upgrade using USB Connected Device and Arduino IDE
 
 1. Preserve your current CheapoDC configuration and WiFi settings by first downloading the CDCConfig.json and CDCWiFi.json files
-from your CheapoDC. This can be done using the Web UI from the [File Management](../README.md#CheapoDC-file-management) page.
+from your CheapoDC. This can be done using the Web UI from the [File Management](../README.md#cheapodc-file-management) page.
 Place both files in the sketch data folder: ***CheapoDC/data***.
 2. Build and upload the new firmware to your device.
    * If upgrading from a pre-V2.1.0 release, make sure to set *Erase All Flash Before Sketch Upload:* ***"Enabled"***  
@@ -58,10 +55,10 @@ Place both files in the sketch data folder: ***CheapoDC/data***.
 ### 4. Upgrade using USB Connected Device and WebFlash
 
 1. WebFlash will erase all flash memory on your CheapoDC. You must backup your current CheapoDC configuration and WiFi settings by first downloading the **CDCConfig.json** and **CDCWiFi.json** files
-from your CheapoDC. This can be done using the Web UI from the [File Management](../README.md#CheapoDC-file-management) page.
+from your CheapoDC. This can be done using the Web UI from the [File Management](../README.md#cheapodc-file-management) page.
 2. Use [WebFlash](https://hcomet.github.io/CheapoDC/CheapoDCFlash.html) to install the latest CheapoDC firmware onto your device.
-3. Once the device has rebooted, it will be in access point mode. Use your computer to connect to the access point, SSID: CheapoDC and Password: CheapoDC.
-4. Browse to the CheapoDC Web UI at [http://CheapoDC.local](http://CheapoDC.local) and login using the default userid and password: admin, admin.
+3. Once the device has rebooted, it will be in access point mode. Use your computer to connect to the access point, SSID: cheapodc and Password: cheapodc.
+4. Browse to the CheapoDC Web UI at [http://cheapodc.local](http://cheapodc.local) and login using the default userid and password: admin, admin.
 5. Upload the previously backed up **CDCConfig.json** and **CDCWifi.json** files using the File Management page.
 5. Goto to the Device Management page and reboot the device to complete the upgrade.
 
@@ -117,7 +114,7 @@ The *Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)* partition scheme provides
 
 To allow for OTA updates, LittleFS storage and some expansion room for CheapoDC firmware the *Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)* partition scheme is used. Although this scheme provides enough application space it provides too little SPIFFS (data partition) space for the CheapoDC HTML, CSS and JS files without compression. The repository [**data source**](../data%20source/) folder contains he original source for these files. The repository [**CheapoDC/data**](../CheapoDC/data/) folder contains minified or compressed versions for installation in the LittleFS formatted data partition.
 
-### Setting Up Your Build Environment
+### Setting Up Your Build Environment\
 
 1. Install the Arduino IDE.  
   **NOTE:** Version 2.3.10 of the Arduino IDE is required. As of CheapoDC V2.3.1 verification of
@@ -151,7 +148,7 @@ To allow for OTA updates, LittleFS storage and some expansion room for CheapoDC 
    * In general, if newer versions of a library are available then only use new subversions not new major versions. CheapoDC v2.3.1 was verified using the versions of libraries listed above.
 
 5. Download the latest firmware release source code from <https://github.com/hcomet/CheapoDC/releases>  
-  **NOTE:** After extracting the release to your filesystem open the CheapoDC.ino file in the Arduino IDE. This will open the full set of source files in the IDE. Now configure the firmware before building it.
+  **NOTE:** After extracting the release to your filesystem open the ***CheapoDC.ino*** file in the Arduino IDE. This will open the full set of source files in the IDE.
 
 >[!TIP]
 >* Many ESP32-C3 board configurations (Dev Module, mini, super mini, micro etc..) have *USB CDC On BOOT:* ***"Disabled"***. This needs to be ***"ENABLED"*** or the Serial Monitor will not work.
@@ -175,11 +172,11 @@ As of V2.2.0 changes to the ***CDCdefines.h*** file are **not** required since a
     **NOTE:** Some ESP32-C3 modules have the Status LED wired so that setting the status pin high is off or reversed. Uncomment this line to reverse the High/Low setting for the status LED pin.  
     ```//#define CDC_REVERSE_HIGH_LOW```  
     *May be changed through the Web UI or API*
-4. Set up the WiFi configuration.  The CheapoDC may operate in either Access Point (AP) mode or Station (ST) mode. The CheapoDC defaults to AP mode when it cannot connect to an access point.  The AP mode SSID will be set to be the same as the hostname which defaults to ***CheapoDC***.  
+4. Set up the WiFi configuration.  The CheapoDC may operate in either Access Point (AP) mode or Station (ST) mode. The CheapoDC defaults to AP mode when it cannot connect to an access point.  The AP mode SSID will be set to be the same as the hostname which defaults to **cheapodc**.  
 **NOTE:** Changing the WiFi configuration is **NOT** recommended. ST Mode settings can be changed in the Web UI while AP Mode settings will be overwritten if Web OTA Update is used.
     * AP Mode settings must be configured in the ***CDCdefines.h*** file:  
-      * Change AP mode password. ***DEFAULT: CheapoDC***.  
-        ```#define CDC_DEFAULT_WIFI_AP_PASSWORD "CheapoDC"```  
+      * Change AP mode password. ***DEFAULT: cheapodc***.  
+        ```#define CDC_DEFAULT_WIFI_AP_PASSWORD "cheapodc"```  
     * ST Mode settings may be configured in either the ***CDCdefines.h*** file or the ***CDCWiFi.json*** file found in the ***data*** folder. Values in found in the ***CDCWiFi.json*** files will be used before using the values in the ***CDCdefines.h*** file. Using the ***CDCWiFi.json*** file to configure WiFi access allows multiple APs and credentials to be defined. How to configure the ***CDCWiFi.json*** file is found [here](#cdcwifijson) while configuring default values in the ***CDCdefines.h*** file is as follows:
       * Change ST mode SSID. ***DEFAULT: defaultSSID***.  
         ```#define CDC_DEFAULT_WIFI_SSID "defaultSSID"```  
@@ -190,9 +187,9 @@ As of V2.2.0 changes to the ***CDCdefines.h*** file are **not** required since a
         ```//#define CDC_ENABLE_WIFI_TX_POWER_MOD WIFI_POWER_8_5dBm```  
         Uncomment to enable. If enabled the default value sets TX power to 8.5dbm. Any of the `wifi_power_t` values found [here](https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFi/src/WiFiGeneric.h#L51-L67) may be used. Extensive testing with WiFi TX Power settings has **NOT** been done.
 
-5. The hostname for the CheapoDC may also be changed. Its recommended that this be done using the [Web UI](../README.md#wifi-configuration). This is only needed if you have multiple CheapoDC controllers on the same network. The default hostname in the ***CDCdefines.h*** file may be modified but it will be  by any hostname value in the [***CDCWiFi.json***](#cdcwifijson) file.: 
-    * Change the default host name. ***DEFAULT: CheapoDC***.  
-      ```#define CDC_DEFAULT_HOSTNAME "CheapoDC"```
+5. The hostname for the CheapoDC may also be changed. Its recommended that this be done using the [Web UI](../README.md#wifi-configuration). This is only needed if you have multiple CheapoDC controllers on the same network. The default hostname in the ***CDCdefines.h*** file may be modified but it will be overridden by any hostname value in the [***CDCWiFi.json***](#cdcwifijson) file.: 
+    * Change the default host name. ***DEFAULT: cheapodc***.  
+      ```#define CDC_DEFAULT_HOSTNAME "cheapodc"```
 
 >[!NOTE]
 >When in access point (AP) mode the SSID for the AP will be the same as the hostname.
@@ -221,8 +218,8 @@ As of V2.2.0 changes to the ***CDCdefines.h*** file are **not** required since a
 If you have not modified the default CDCWiFi.json then the CheapoDC will enter AP (Access Point) mode when booted the first time.
 
 * Connect to the access point, SSID: CheapoDC and Password: CheapoDC.
-* Browse to the CheapoDC Web UI at [http://CheapoDC.local](http://CheapoDC.local) to configure your device. When prompted login using the default userid and password: admin, admin. You should be on the [Dashboard](../README.md#CheapoDC-dashboard) page.
-* Go to the [Device Management](../README.md#CheapoDC-device-management) page by clicking on the button at the bottom of the page.
+* Browse to the CheapoDC Web UI at [http://cheapodc.local](http://cheapodc.local) to configure your device. When prompted login using the default userid and password: admin, admin. You should be on the [Dashboard](../README.md#cheapodc-dashboard) page.
+* Go to the [Device Management](../README.md#cheapodc-device-management) page by clicking on the button at the bottom of the page.
 * Scroll down to [WiFi Configuration](../README.md#wifi-configuration) and configure your WiFi SSID and Password. You'll need to [Reboot](../README.md#reboot-device) the CheapoDC for the WiFi changes to take effect.
 * After rebooting. The CheapoDC should be connected to your WiFi network. Refresh your browser and stay on the Device Management page.
 * Configure the [Controller Outputs](../README.md#controller-output-configuration) if needed. Output 0 and 1 are always dew controller outputs and by default mapped to GPIO pins 0 and 1. Outputs 2 to 5 may be configured as Controller, PWM or Boolean. They are Disabled by default. Outputs **must** be mapped to a GPIO pin first before an [Output Mode](../README.md#output-modes) may be set.  
@@ -231,17 +228,17 @@ If you have not modified the default CDCWiFi.json then the CheapoDC will enter A
 * Set up the Humidity Sensor if you have [added one to your device](../README.md#humidity-sensor-configuration). A [Reboot](../README.md#reboot-device) of the device will be required for SDA and SCL pin changes to take effect.  
   For the ESP32-C3 SuperMini GPIO pins 9 (SCL) and 10 (SDA) have been validated.
 * [Change the Status LED](../README.md#status-led-configuration) GPIO pin and High Value setting if needed. GPIO pin 8 is the default while setting it to -1 will disable the LED.
-* Go to the [Controller Configuration](../README.md#CheapoDC-controller-configuration) page to set up the parameters for the dew controller, weather query and your location. Dew controller parameters are explained in the [Dew Control Algorithm](../README.md#how-the-dew-control-algorithm-works) section.
+* Go to the [Controller Configuration](../README.md#cheapodc-controller-configuration) page to set up the parameters for the dew controller, weather query and your location. Dew controller parameters are explained in the [Dew Control Algorithm](../README.md#how-the-dew-control-algorithm-works) section.
 
 Your CheapoDC should now be ready to use.
 
 ## Configuration Files
 
-All of the configuration information for the CheapoDC is stored in two files save to the data partition on the device.
+All the configuration information for the CheapoDC is stored in two files saved to the data partition on the device.
 
 ### CDCWiFi.json
 
-This file provides a list of WiFi access points that will be tried by the CheapoDC to establish a network connection. The Hostname and WiFi access point information may be modified using the [Web UI](../README.md#wifi-configuration). This file may also be edited and uploaded using the [File Management](../README.md#CheapoDC-file-management) page.
+This file provides a list of WiFi access points that will be tried by the CheapoDC to establish a network connection. The Hostname and WiFi access point information may be modified using the [Web UI](../README.md#wifi-configuration). This file may also be edited and uploaded using the [File Management](../README.md#cheapodc-file-management) page.
 
 The file content is json formatted using "name":"value" pairs.
 
@@ -253,23 +250,23 @@ The example shows settings for two access points in the "wifi" section. This can
 ```{"ssid":"FakeSSID1","password":"Password1"}```
 2. To set up a second AP (or more) then update "FakeSSID2" and "Password2" for the second AP (or add more entries separated by commas for more APs). If you only want one AP, then delete the entry including the preceding comma.  
 ```{"ssid":"FakeSSID2","password":"Password2"}```
-3. You can also change the "hostname" from the default of ***CheapoDC***.  
-```"hostname":"CheapoDC"```  
+3. You can also change the "hostname" from the default of ***cheapodc***.  
+```"hostname":"cheapodc"```  
 **Note:** Changing the hostname will also change the SSID for the device when in Access Point mode.
 4. Changing "connectAttempts" will change then number of times the CheapoDC will attempt to connect to an access point before moving to the next access point in the list.  
 ```"connectAttempts":"10"```
 5. Changing "tryAPs" will change the number of times the CheapoDC will loop through the list of access points before switching to Access Point (AP) mode.  
 ```"tryAPs":"1"```
 
-If CheapoDC fails to connect to an access point in Station Mode, then it will switch to Access Point (AP) mode. The AP SSID will be the same as the hostname with a default of *CheapoDC*. The AP password is always *CheapoDC* and can only be changed in the  [***CDCdefines.h***](#configure-firmware-in-the-cdcdefinesh-file) file.
+If CheapoDC fails to connect to an access point in Station Mode, then it will switch to Access Point (AP) mode. The AP SSID will be the same as the hostname with a default of *cheapodc*. The AP password is always *cheapodc* and can only be changed in the  [***CDCdefines.h***](#configure-firmware-in-the-cdcdefinesh-file) file.
 
 If no ***CDCWiFi.json*** file is found, then the values for WiFi configuration will be taken from the [***CDCdefines.h***](#configure-firmware-in-the-cdcdefinesh-file) file.
 
 ### CDCConfig.json
 
-This file is used to save the dew controller configuration between power cycles. If the file is not present, then the values defined in the ***CDCdefines.h*** file (the firmware defaults) will be used. The CheapoDC checks for changes to the controller's configuration every 10 seconds and if a change is detected then the full ***CDCdefines.h*** file will be written to the LittleFS file system on the controller.
+This file is used to save the device and dew controller configuration between power cycles. If the file is not present, then the values defined in the ***CDCdefines.h*** file (the firmware defaults) will be used. The CheapoDC checks for changes to any configuration values every 10 seconds and if a change is detected then the full ***CDCConfig.json*** file will be written to the LittleFS file system on the device.
 
-Controller configuration may be modified via the [Web UI](../README.md/#web-ui) or the [CheapoDC API](../README.md/#CheapoDC-api). The [CheapoDC commands](../README.md/#CheapoDC-commands) which support a ***Setter*** function also represent the values stored in the ***CDCConfig.json*** file.
+CheapoDC device and controller configuration may be modified via the [Web UI](../README.md/#web-ui) or the [CheapoDC API](../README.md/#cheapodc-api). The [CheapoDC commands](../README.md/#cheapodc-commands) which support a ***Setter*** function also represent the values stored in the ***CDCConfig.json*** file.
 
 ## Web OTA Root CA Issue
 

--- a/CheapoDC/data/config.html
+++ b/CheapoDC/data/config.html
@@ -332,7 +332,7 @@
 <button type=button class=bfooter onclick='document.location="../otaIndex"'>Device Management</button>
 <button type=button class=bfooter onclick='document.location="../listFiles"'>File Management</button>
 <hr class=footerBhr>
-<div class=attribution>Cheapo Dew Controller - &copy; 2025 - Release: %FW% <br>(Heap: %HP%, File space: %LFS%)</div>
+<div class=attribution>Cheapo Dew Controller - &copy; 2026 - Release: %FW% <br>(Heap: %HP%, File space: %LFS%)</div>
 </footer>
 </div>
 <script src=CDCjs.js></script></body>

--- a/CheapoDC/data/dashboard.html
+++ b/CheapoDC/data/dashboard.html
@@ -37,7 +37,7 @@
 <button type=button class=bfooter onclick='document.location="../otaIndex"'>Device Management</button>
 <button type=button class=bfooter onclick='document.location="../listFiles"'>File Management</button>
 <hr class=footerBhr>
-<div class=attribution>Cheapo Dew Controller - &copy; 2025 - Release: %FW% <br>(Heap: %HP%, File space: %LFS%)</div>
+<div class=attribution>Cheapo Dew Controller - &copy; 2026 - Release: %FW% <br>(Heap: %HP%, File space: %LFS%)</div>
 </footer></div>
 <script src=CDCjs.js></script>
 </body>

--- a/CheapoDC/data/listfiles.html
+++ b/CheapoDC/data/listfiles.html
@@ -36,7 +36,7 @@
 <button type=button class=bfooter onclick='document.location="../otaIndex"'>Device Management</button>
 <button type=button class=bfooterDisabled disabled>File Management</button>
 <hr class=footerBhr>
-<div class=attribution>Cheapo Dew Controller - &copy; 2025 - Release: %FW% <br>(Heap: %HP%, File space: %LFS%)</div>
+<div class=attribution>Cheapo Dew Controller - &copy; 2026 - Release: %FW% <br>(Heap: %HP%, File space: %LFS%)</div>
 </footer></div>
 <script>document.getElementById("file2").addEventListener("change",(function(){document.getElementById("iupload").disabled=!1}))</script>
 <script src=CDCjs.js></script>

--- a/CheapoDC/data/otaindex.html
+++ b/CheapoDC/data/otaindex.html
@@ -350,7 +350,7 @@
 <button type=button class=bfooterDisabled disabled>Device Management</button>
 <button type=button class=bfooter onclick='document.location="../listFiles"'>File Management</button>
 <hr class=footerBhr>
-<div class=attribution>Cheapo Dew Controller - &copy; 2025 - Release: %FW% <br>(Heap: %HP%, File space: %LFS%)</div>
+<div class=attribution>Cheapo Dew Controller - &copy; 2026 - Release: %FW% <br>(Heap: %HP%, File space: %LFS%)</div>
 </footer>
 </div>
 <script>window.onload=function(){httpOTAAvailability("%FWUP%"),loadWifi()},document.getElementById("file1").addEventListener("change",(function(){document.getElementById("iupload").disabled=!1})),document.getElementById("oldpassword").addEventListener("input",(function(){checkPasswordUpdate()})),document.getElementById("newpassword").addEventListener("input",(function(){checkPasswordUpdate()})),document.getElementById("confpassword").addEventListener("input",(function(){checkPasswordUpdate()})),document.getElementById("HTTPOTAPWD").addEventListener("input",(function(){document.getElementById("iupdate").disabled=!1})),document.getElementById("wifiName").addEventListener("change",(function(){wifiSelectChange()})),document.getElementById("wifiSSID").addEventListener("input",(function(){document.getElementById("wifiButton").disabled=!1})),document.getElementById("wifiPassword").addEventListener("input",(function(){document.getElementById("wifiButton").disabled=!1})),document.getElementById("hostname").addEventListener("input",(function(){document.getElementById("hnButton").disabled=!1}))</script>

--- a/README.md
+++ b/README.md
@@ -14,14 +14,17 @@ A primary goal was to keep the project cheap, simple and easy with:
 * Comprehensive [Web UI](#web-ui) for configuration and management
 * [INDI](https://www.indilib.org/) and [StellarMate](https://stellarmate.com/) support 'out-of-the-box'
 
-CheapoDC can select from four weather sources to provide the local temperature and humidity. The first two, OpenWeather and Open-Meteo, leverage the ESP32 WiFi
+CheapoDC can select from four weather sources to provide the local temperature and humidity. 
+* The first two, **OpenWeather** and **Open-Meteo**, leverage the ESP32 WiFi
 capability to query one of the two open weather service APIs. Either the [OpenWeather](https://openweathermap.org/) API
 or the [Open-Meteo](https://open-meteo.com/) API may be used to retrieve ambient temperature, humidity and dew point
 for the controller's geographic location. No additional
-components, such as temperature or humidity probes, are required with these weather sources. As a third weather source option an External Sources, such as a personal weather station, can push weather information to the CheapoDC via the API. Then as a fourth option an optional Humidity Sensor may be added to the CheapoDC to provide the required weather data and selected as the Internal Source.
+components, such as temperature or humidity probes, are required with these weather sources. 
+* The third weather source option, **External Source**, allows weather information to be pushed to the CheapoDC via the API. A personal weather station may be leveraged for local weather data using this option.
+* The fourth option, **Internal Source**, requires an optional Humidity Sensor be added to the CheapoDC to provide required weather data.
 
 The CheapoDC may be set up using a basic configuration with two dew strap outputs or it may be configured with up to
-four additional outputs or the optional humidity sensor. Each CheapoDC Output is controlled by a separate MOSFET module tied to one of the ESP32's
+four additional outputs or the optional humidity sensor. Each CheapoDC Output is controlled by a separate MOSFET module tied to one of the ESP32
 GPIO pins. The four additional outputs may be configured to be managed either automatically using the CheapoDC dew
 control algorithm, along with the two main dew controller outputs,
 or manually via the Web UI or API. Dew control algorithm managed pins and thus dew strap outputs are all tied to the
@@ -31,10 +34,10 @@ CheapoDC hardware details can be found in the [Hardware](#hardware) section of t
 
 CheapoDC firmware installation details may be found with the source code in the [CheapoDC/README.md](./CheapoDC/README.md#installing-cheapodc). Installation may be done by:
 
-* Using WebFlash, a web based utility that allows for the installation of the latest firmware directly to your ESP32-C3 based device.
+* Using WebFlash, a web-based utility that allows for the installation of the latest firmware directly to your ESP32-C3 based device.
 * Building it yourself with the Arduino IDE.
 
-CheapoDC also supports web based Over-the-air (OTA) upgrades of the firmware using the CheapoDC Web UI.
+CheapoDC also supports web-based Over-the-air (OTA) upgrades of the firmware using the CheapoDC Web UI.
 
 # How the Dew Control Algorithm Works
 
@@ -88,7 +91,7 @@ Example 1 is primarily a reference image to illustrate the variables defined abo
 
 Example 2 shows changing the values of the controller configuration variables can affect the Power Output calculation.
 
-* The Set Point, SP = -2°C, and the Reference Temperature, RT = 8°C, the same as in Example 1. However changing the Track Point Offset, now TPO = 2°C, and the Tracking Range, now TR = 10°C, has changed the Power Output as well as flattening the Power Output curve.
+* The Set Point, SP = -2°C, and the Reference Temperature, RT = 8°C, the same as in Example 1. However, changing the Track Point Offset, now TPO = 2°C, and the Tracking Range, now TR = 10°C, has changed the Power Output as well as flattening the Power Output curve.
 * The Maximum Output has been increased, MaxO = 100%, to allow full power output to be reached at 0&deg;C.
 
 ![Example 2](images/example2.jpg)
@@ -107,7 +110,7 @@ The Controller Mode selects the overall operating mode of the dew controller.
 
 #### Manual
 
-* Controller output is manually controlled by setting the **Dew Controller Output** either through the Web UI or the API. When in Manual mode the the periodic Power Output calculation is suspended. Using Manual control is an option if internet access for OpenWeather API queries is not available.
+* Controller output is manually controlled by setting the **Dew Controller Output** either through the Web UI or the API. When in Manual mode the periodic Power Output calculation is suspended. Using Manual control is an option if internet access for OpenWeather API queries is not available.
 
 #### Off
 
@@ -123,7 +126,7 @@ The Set Point Mode selects what will be used as the SetPoint for calculating Pow
 
 #### Temperature
 
-* Uses a **Temperature Set Point** value input via the Web UI or API as the Set Point for calculating output. If the CheapoDC is being used without internet access then this mode allows a Set Point to be defined when a the DeW Point cannot be determined through the OpenWeather API.
+* Uses a **Temperature Set Point** value input via the Web UI or API as the Set Point for calculating output. If the CheapoDC is being used without internet access, then this mode allows a Set Point to be defined when the Dew Point cannot be determined through the OpenWeather API.
 
 #### Midpoint
 
@@ -135,12 +138,12 @@ The Temperature Mode selects how the Reference Temperature will be determined fo
 
 #### Weather Source
 
-* Uses the Ambient Temperature returned by the selected Weather Source.This is then used as the Reference Temperature for calculating the controller output.
+* Uses the Ambient Temperature returned by the selected Weather Source. This is then used as the Reference Temperature for calculating the controller output.
 
 #### External Input
 
 * Use the **External Input** temperature set through the [Web UI](#cheapodc-controller-configuration) or [API](#cheapodc-api) as the reference temperature for calculating the controller output. This may be the preferred mode when using the controller with KStars/Indi. The CheapoDC [Indilib driver](#indi-driver) can use a temperature probe attached to a focuser as the external input.  
-<br>**NOTE:** If no temperature values have been set for External Input then a value of **-127.0°C** will be shown. The Controller, when in Automatic Mode with Temperature Mode set to External Input,  will set output power at the configured minimum output until a value is set via the WebUI or API.
+<br>**NOTE:** If no temperature values have been set for External Input, then a value of **-127.0°C** will be shown. The Controller, when in Automatic Mode with Temperature Mode set to External Input,  will set output power at the configured minimum output until a value is set via the WebUI or API.
 
 ## Hardware
 
@@ -156,10 +159,10 @@ If you are looking to add the optional SHT30 Humidity sensor to support a comple
 ### Component list
 
 * ESP32-C3 SuperMini (Other ESP32 modules should work but this one is very small and low priced) Example: [https://www.aliexpress.com/item/1005005967641936.html?spm=a2g0o.order_list.order_list_main.10.3b2c1802dRy3Tw](https://www.aliexpress.com/item/1005005967641936.html?spm=a2g0o.order_list.order_list_main.10.3b2c1802dRy3Tw)
-* Buck converter to reduce 12V to 5V. I used an [LM2596 Module](https://www.amazon.ca/dp/B08Q2YKJ6Q?psc=1&ref=ppx_yo2ov_dt_b_product_details). You could also use an [MP1584EN Module](https://www.amazon.ca/eBoot-MP1584EN-Converter-Adjustable-Module/dp/B01MQGMOKI/ref=pd_sbs_d_sccl_2_3/141-9725081-7037101?pd_rd_w=UMd8F&content-id=amzn1.sym.ca022dba-8a59-468d-95a1-3216f611a75e&pf_rd_p=ca022dba-8a59-468d-95a1-3216f611a75e&pf_rd_r=4WWMQ6QG50JQ2BTYP273&pd_rd_wg=OCFjo&pd_rd_r=381f4abb-88a8-4856-a51f-39d3190099fa&pd_rd_i=B01MQGMOKI&th=1). These modules often have an adjustable output. You'll need to use a Volt meter to adjust the output to 5 volts before hooking it up.
+* Buck converter to reduce 12V to 5V. I used an [LM2596 Module](https://www.amazon.ca/dp/B08Q2YKJ6Q?psc=1&ref=ppx_yo2ov_dt_b_product_details). You could also use an [MP1584EN Module](https://www.amazon.ca/eBoot-MP1584EN-Converter-Adjustable-Module/dp/B01MQGMOKI/ref=pd_sbs_d_sccl_2_3/141-9725081-7037101?pd_rd_w=UMd8F&content-id=amzn1.sym.ca022dba-8a59-468d-95a1-3216f611a75e&pf_rd_p=ca022dba-8a59-468d-95a1-3216f611a75e&pf_rd_r=4WWMQ6QG50JQ2BTYP273&pd_rd_wg=OCFjo&pd_rd_r=381f4abb-88a8-4856-a51f-39d3190099fa&pd_rd_i=B01MQGMOKI&th=1). These modules often have an adjustable output. You'll need to use a Voltmeter to adjust the output to 5 volts before hooking it up.
 * Two [dual-MOSFET Modules](https://www.amazon.ca/dp/B08ZNDG6RY?psc=1&ref=ppx_yo2ov_dt_b_product_details) to handle output to the dew straps while being able to be triggered by the 3.3V levels from the ESP32 PWM pins.
 * A resettable fuse that can handle 5A. An example [5A PPTC](https://www.amazon.ca/10pcs-5000MA-Resettable-RGEF500-GF500/dp/B092T9Q3QR/ref=sr_1_4?crid=3KNZXWN5ZIERR&dib=eyJ2IjoiMSJ9.y5Pp17w_i-KzaprejYOYzM_8u_S5MY_jz1z932C2gBBmx5zcGFKHMHtP6qYXScM_-6ii9W8lDuEq5tbkCUQdYOFESDzjnASBHIusx7zAFOkhc6SNPrOH4O8ExB9WzAI-XgtIUvz-EvjfyOzjX4IN8iGl2GSffYGCb1BvIzldhIbrwCyyvNRyEfUCehiFknfJ5Uz1PSdPnC0BJjzSZp7Frh_EDLOF4CjpyeUQckj0FTQ347ehfh3jy3kHSu3I2iTOEaQZMRdqjpkW_NBOUMMsZsbeRdkMtzq0cIrGcsbUdhk.8jKyynsByh2dYlS0gLu9IdNbxiIm4iDIQv6g0ucFzCc&dib_tag=se&keywords=5a+pptc&qid=1709138849&sprefix=5a+pptc%2Caps%2C80&sr=8-4)
-* Optionally an LED and resistor for the status LED. Many astrophotographers do not want power LEDs or lights of any sort on their equipment. If you fall into this category then just use the ESP32 onboard LED as the status LED. If you would prefer a visible status LED on your project case then you may optionally add one. Status LED details may be found in the [Status LED Section](#cheapodc-status-led).  
+* Optionally an LED and resistor for the status LED. Many astrophotographers do not want power LEDs or lights of any sort on their equipment. If you fall into this category, then just use the ESP32 onboard LED as the status LED. If you would prefer a visible status LED on your project case, then you may optionally add one. Status LED details may be found in the [Status LED Section](#cheapodc-status-led).  
 In my implementation I used a red LED connected to the same pin as the onboard LED, pin 8. I used a 1K resistor to keep the LED fairly dim while still working.
 * Some assorted hardware:
   * 12VDC 5.5mm x 2.1mm socket. Common socket size used for Astronomy.
@@ -171,13 +174,13 @@ In my implementation I used a red LED connected to the same pin as the onboard L
 ![Wiring Diagram](images/wiring.jpg)
 
 The default configuration for the basic dual output controller uses Controller Outputs, 0 and 1, mapped to GPIO pins 0 and 1.
-If you cannot use these GPIO pins then they may be changed using the Web UI on the [Device Management](#cheapodc-device-management)
+If you cannot use these GPIO pins, then they may be changed using the Web UI on the [Device Management](#cheapodc-device-management)
 page or the default values may be changed in the [CDCDefines.h](CheapoDC/README.md#configure-firmware-in-the-cdcdefinesh-file) file
 before building the firmware.
 
 ### Working Implementation
 
-Assembled in a 6 inch long piece of 2"x1" aluminum channel. This also has Pin 8, which is the status LED, connected to an extra LED on the left side for external visibility. The ESP32-C3 is also mounted in some protoboard to make the wiring easier. If you plan to use a small case like this, use silicone hookup wire. The extra flexibility of silicone wire will save a lot of frustration. I used 22 awg wire for the 5V and 3.3V ESP32 connections and 18 awg wire for the 12V connections.
+Assembled in a 6 inch piece of 2"x1" aluminum channel. This also has Pin 8, which is the status LED, connected to an extra LED on the left side for external visibility. The ESP32-C3 is also mounted in some protoboard to make the wiring easier. If you plan to use a small case like this, use silicone hookup wire. The extra flexibility of silicone wire will save a lot of frustration. I used 22 awg wire for the 5V and 3.3V ESP32 connections and 18 awg wire for the 12V connections.
 
 ![Working Prototype](images/prototype.jpg)
 
@@ -211,7 +214,7 @@ pen-Meteo, an open API based weather service, is the default Weather Source for 
 
 ### Which Open Weather Service to use?
 
-Both services require a location using Latitude and Longitude which you can set using the CheapoDC [Web UI](/README.md#web-ui) or [CHeapoDC API](#cheapodc-api). Both sources will use weather stations close to the provided coordinates. OpenWeather provides the name of the weather station used in its response. Open-Meteo does not. If run side-by-side with the same co-ordinates they provide slightly different results. You may want to check which service provides the best results for your location.
+Both services require a location using Latitude and Longitude which you can set using the CheapoDC [Web UI](/README.md#web-ui) or [CheapoDC API](#cheapodc-api). Both sources will use weather stations close to the provided coordinates. OpenWeather provides the name of the weather station used in its response. Open-Meteo does not. If run side-by-side with the same co-ordinates they provide slightly different results. You may want to check which service provides the best results for your location.
 
 As indicated the default service is Open-Meteo. This is primarily because no registration is required to use the open service.
 
@@ -261,13 +264,13 @@ Note that a Controller Output Pin to GPIO Pin mapping must be set before an Outp
 Shows current network information and allows you to configure the hostname and WiFi access point to use for network access. CheapoDC can be configured to step through multiple access points to make a WiFi connection.
 
 * Network Information
-  * Wifi Mode: STA = Station Mode, AP = Access Point Mode.
+  * WiFi Mode: STA = Station Mode, AP = Access Point Mode.
   * Hostname: Current active hostname. If updated a reboot is required to see the new hostname.  
   **Note:** Changing the hostname will also change the SSID for the device when in Access Point Mode.
   * IP Address.
 * Configure WiFi
-  * Name: Allows you to pick an access point for editing the password. Or, select `Add WiFi` to add an access point.
-  * SSID: Is the access point SSID point to add or edit. To delete an access point blank out the SSID and click **Update**.
+  * Name: Allows you to pick an access point for editing the password. Or select `Add WiFi` to add an access point.
+  * SSID: Is the access point SSID point to add or edit. To delete an access point, blank out the SSID and click **Update**.
   * Password: Is the password for the access point. **Show Password** will only work for adding a new WiFi access point.
 
 Changes to any of the WiFi Configuration setting require a reboot to take effect.
@@ -278,7 +281,7 @@ Changing the default password of ***admin*** to your own password is recommended
 
 #### Humidity Sensor Configuration
 
-Used to configure which pins are used for by the SHT3x humidity sensor. The humidity sensor uses the I2C protocol and two GPIO pins are required. One for the I2C SDA (data) line and one for the I2C SCL (clock) line. If using the humidity sensor then its recommend to use pin 10 for SDA GPIO and pin 9 for SCL GPIO. If not using the humidity sensor then leave the two values set to -1. If either setting has a negative value then the firmware will not attempt to intialize I2C and the humidity sensor.
+Used to configure which pins are used for by the SHT3x humidity sensor. The humidity sensor uses the I2C protocol and two GPIO pins are required. One for the I2C SDA (data) line and one for the I2C SCL (clock) line. If using the humidity sensor, then it's recommended to use pin 10 for SDA GPIO and pin 9 for SCL GPIO. If not using the humidity sensor, then leave the two values set to -1. If either setting has a negative value, then the firmware will not attempt to initialize I2C and the humidity sensor.
 
 #### Status LED Configuration
 
@@ -303,15 +306,15 @@ The CheapoDC uses LittleFS for file storage on the ESP32. Although LittleFS supp
 
 ## CheapoDC Status LED
 
-The Status LED is used to provide information about the current status of the CheapoDC. Status blinking lasts for 10 seconds. It will blink as WiFi access attempts are made. If a Station mode connection is successfully made to an access point then the status LED will slow blink (1 second cycle). If no connection is made then the CheapoDC will go into Access Point mode. The status LED will then fast blink (200ms cycle).
+The Status LED is used to provide information about the current status of the CheapoDC. Status blinking lasts for 10 seconds. It will blink as WiFi access attempts are made. If a Station mode connection is successfully made to an access point, then the status LED will slow blink (1 second cycle). If no connection is made, then the CheapoDC will go into Access Point mode. The status LED will then fast blink (200ms cycle).
 
 The status LED will also blink for 10 seconds after the controller changes the power output and after an API or Web UI driven controller configuration change.
 
-If the status LED is not turning off after connecting to WiFI or after the 10 second blink then you may need to reverse the High value setting. This can also be done in the Web UI by changing the High Value setting in [Status LED Configuration](#status-led-configuration).
+If the status LED is not turning off after connecting to WiFI or after the 10 second blink, then you may need to reverse the High value setting. This can also be done in the Web UI by changing the High Value setting in [Status LED Configuration](#status-led-configuration).
 
 ## CheapoDC API
 
-The CheapoDC provides API access to all configuration and data items available through the [Web UI](/README.md#web-ui). There is no authentication support in the API but the API also does not support firmware OTA updates or file management. These can only be done through the Web UI.
+The CheapoDC provides API access to all configuration and data items available through the [Web UI](/README.md#web-ui). There is no authentication support in the API, but the API also does not support firmware OTA updates or file management. These can only be done through the Web UI.
 
 CheapoDC supports two API mechanisms:
 
@@ -333,7 +336,7 @@ The APIs use the same commands which are listed in the top of [CDCommands.cpp](/
   * JSON ENUM, for enumerated values like Controller Mode.
     * ie: "{"Mode":["Automatic","Manual","Off"]}"
 
-The table below provides a list of the commands but the code is the final correct source of truth here.
+The table below provides a list of the commands, but the code is the final correct source of truth here.
 
 * String maximum lengths are identified in the table.
 * Floats are truncated to 2 decimal places.
@@ -470,4 +473,5 @@ Driver version 1.2 supports the latest versions of the CheapoDC firmware adding 
   * [Sensirion I²C SHT3X by Sensirion](https://github.com/Sensirion/arduino-i2c-sht3x)
   * [Sensirion Core by Sensirion](https://github.com/Sensirion/arduino-core/)
   * [Time by Michael Margolis](https://playground.arduino.cc/Code/Time/)
+  * [ESP32CertBundle by TANAKA Masayuki](https://github.com/tanakamasayuki/ESP32CertBundle)  
 * The [WebFlash](https://hcomet.github.io/CheapoDC/CheapoDCFlash.html) capability uses [ESP Web Tools](https://esphome.github.io/esp-web-tools/) from [Home Assistant](https://www.home-assistant.io/).

--- a/README.md
+++ b/README.md
@@ -27,13 +27,12 @@ control algorithm, along with the two main dew controller outputs,
 or manually via the Web UI or API. Dew control algorithm managed pins and thus dew strap outputs are all tied to the
 same ESP32 PWM channel and will have the same output.
 
-CheapoDC hardware build details can be found in the [Hardware](#hardware) section of this document.
+CheapoDC hardware details can be found in the [Hardware](#hardware) section of this document.
 
-CheapoDC firmware may installed on your device using one of the following methods:
+CheapoDC firmware installation details may be found with the source code in the [CheapoDC/README.md](./CheapoDC/README.md#installing-cheapodc). Installation may be done by:
 
-* Using the Arduino IDE: Details on how to build the CheapoDC firmware as well as information about the latest
-firmware release may be found with the source code in the [CheapoDC/README.md](./CheapoDC#webflash-as-an-option).
-* WebFlash: A web based utility that allows for the installation of the latest firmware directly to your ESP32-C3 based device.
+* Using WebFlash, a web based utility that allows for the installation of the latest firmware directly to your ESP32-C3 based device.
+* Building it yourself with the Arduino IDE.
 
 CheapoDC also supports web based Over-the-air (OTA) upgrades of the firmware using the CheapoDC Web UI.
 

--- a/data source/config.html
+++ b/data source/config.html
@@ -353,7 +353,7 @@
             <button type="button" class="bfooter" onclick="document.location='../otaIndex'">Device Management</button>
             <button type="button" class="bfooter" onclick="document.location='../listFiles'">File Management</button>
             <hr class="footerBhr">
-            <div class="attribution">Cheapo Dew Controller - &copy; 2025 - Release: %FW% <br />(Heap: %HP%, File space:
+            <div class="attribution">Cheapo Dew Controller - &copy; 2026 - Release: %FW% <br />(Heap: %HP%, File space:
                 %LFS%)</div>
         </footer>
     </div>

--- a/data source/dashboard.html
+++ b/data source/dashboard.html
@@ -38,7 +38,7 @@
  <button type="button" class="bfooter" onclick="document.location='../otaIndex'">Device Management</button>
  <button type="button" class="bfooter" onclick="document.location='../listFiles'">File Management</button>
  <hr class="footerBhr">
- <div class="attribution">Cheapo Dew Controller - &copy; 2025 - Release: %FW% <br />(Heap: %HP%, File space: %LFS%)</div>
+ <div class="attribution">Cheapo Dew Controller - &copy; 2026 - Release: %FW% <br />(Heap: %HP%, File space: %LFS%)</div>
 </footer></div>
 <script src=CDCjs.js></script>
 </body>

--- a/data source/listfiles.html
+++ b/data source/listfiles.html
@@ -37,7 +37,7 @@
  <button type="button" class="bfooter" onclick="document.location='../otaIndex'">Device Management</button>
  <button type="button" class="bfooterDisabled" disabled >File Management</button> <!--onclick="document.location='../listFiles'"--> 
  <hr class="footerBhr">
- <div class="attribution">Cheapo Dew Controller - &copy; 2025 - Release: %FW% <br />(Heap: %HP%, File space: %LFS%)</div>
+ <div class="attribution">Cheapo Dew Controller - &copy; 2026 - Release: %FW% <br />(Heap: %HP%, File space: %LFS%)</div>
 </footer></div>
 <script>
 document.getElementById('file2').addEventListener('change', function() {document.getElementById('iupload').disabled = false;  });

--- a/data source/otaindex.html
+++ b/data source/otaindex.html
@@ -374,7 +374,7 @@
          <!-- onclick="document.location='../otaIndex'"-->
          <button type="button" class="bfooter" onclick="document.location='../listFiles'">File Management</button>
          <hr class="footerBhr">
-         <div class="attribution">Cheapo Dew Controller - &copy; 2025 - Release: %FW% <br />(Heap: %HP%, File space:
+         <div class="attribution">Cheapo Dew Controller - &copy; 2026 - Release: %FW% <br />(Heap: %HP%, File space:
             %LFS%)</div>
       </footer>
    </div>


### PR DESCRIPTION
V2.3.1 Fixes
* From @wadouk:
  * CDCWiFi.json values for ***tryAPs*** and ***connectAttemps*** not being read and applied properly.
  * Calls to `getLocalTime` should have 10ms timeout to prevent 5s timeout when in AP mode.
* Fix Web OTA Update by adding support for latest esp32FOTA and esp32 CA certificate bundle.
  * #19 
* Fix Internal Source error path when humidity sensor not connected.
* Fix File Management page file list truncation issues due to changes in latest ESP Async WebServer.